### PR TITLE
remove spurious link definition

### DIFF
--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1260,28 +1260,28 @@ groups to use this information as they see fit".
 
 IANA is requested to allocate the following tags in the "CBOR Tags" registry {{!IANA.cbor-tags}}, preferably with the specific CBOR tag value requested:
 
-|     Tag | Data Item                           | Semantics                                                            | Reference |
-|     --- | ---------                           | ---------                                                            | --------- |
-|     500 | tag                                 | A corim, one out of $concise-rim-type-choice, see {{sec-corim-tags}} | {{&SELF}} |
-|     501 | map                                 | A corim-map, see {{sec-corim-map}}                                   | {{&SELF}} |
-|     502 | tag                                 | A signed-corim, see {{sec-corim-signed}}                             | {{&SELF}} |
-| 503-504 | any                                 | Earmarked for CoRIM                                                  | {{&SELF}} |
-|     505 | bytes                               | An encoded concise-swid-tag, see {{sec-corim-tags}}                  | {{&SELF}} |
-|     506 | bytes                               | An encoded concise-mid-tag, see {{sec-corim-tags}}}                  | {{&SELF}} |
-|     507 | any                                 | Earmarked for CoRIM                                                  | {{&SELF}} |
-|     508 | bytes                               | An encoded concise-bom-tag, see {{sec-corim-tags}}}                  | {{&SELF}} |
-| 509-549 | any                                 | Earmarked for CoRIM                                                  | {{&SELF}} |
-|     550 | bytes .size 33                      | tagged-ueid-type, see {{sec-common-ueid}}                            | {{&SELF}} |
-|     551 | int                                 | tagged-int-type, see {{sec-common-tagged-int}}                       | {{&SELF}} |
-|     552 | uint                                | tagged-svn, see {{sec-comid-svn}}                                    | {{&SELF}} |
-|     553 | uint                                | tagged-min-svn, see {{sec-comid-svn}}                                | {{&SELF}} |
-|     554 | text                                | tagged-pkix-base64-key-type, see {{sec-crypto-keys}}                 | {{&SELF}} |
-|     555 | text                                | tagged-pkix-base64-cert-type, see {{sec-crypto-keys}}                | {{&SELF}} |
-|     556 | text                                | tagged-pkix-base64-cert-path-type, see {{sec-crypto-keys}}           | {{&SELF}} |
-|     557 | digest: [alg: int/text, val: bytes] | tagged-thumbprint-type, see {{sec-common-hash-entry}}                | {{&SELF}} |
-| 558-559 | any                                 | Earmarked for CoRIM                                                  | {{&SELF}} |
-|     560 | bytes                               | $raw-value-type-choice, see {{sec-comid-raw-value-types}}            | {{&SELF}} |
-| 561-599 | any                                 | Earmarked for CoRIM                                                  | {{&SELF}} |
+|     Tag | Data Item           | Semantics                                                            | Reference |
+|     --- | ---------           | ---------                                                            | --------- |
+|     500 | `tag`               | A corim, one out of $concise-rim-type-choice, see {{sec-corim-tags}} | {{&SELF}} |
+|     501 | `map`               | A corim-map, see {{sec-corim-map}}                                   | {{&SELF}} |
+|     502 | `tag`               | A signed-corim, see {{sec-corim-signed}}                             | {{&SELF}} |
+| 503-504 | `any`               | Earmarked for CoRIM                                                  | {{&SELF}} |
+|     505 | `bytes`             | An encoded concise-swid-tag, see {{sec-corim-tags}}                  | {{&SELF}} |
+|     506 | `bytes`             | An encoded concise-mid-tag, see {{sec-corim-tags}}}                  | {{&SELF}} |
+|     507 | `any`               | Earmarked for CoRIM                                                  | {{&SELF}} |
+|     508 | `bytes`             | An encoded concise-bom-tag, see {{sec-corim-tags}}}                  | {{&SELF}} |
+| 509-549 | `any`               | Earmarked for CoRIM                                                  | {{&SELF}} |
+|     550 | `bytes .size 33`    | tagged-ueid-type, see {{sec-common-ueid}}                            | {{&SELF}} |
+|     551 | `int`               | tagged-int-type, see {{sec-common-tagged-int}}                       | {{&SELF}} |
+|     552 | `uint`              | tagged-svn, see {{sec-comid-svn}}                                    | {{&SELF}} |
+|     553 | `uint`              | tagged-min-svn, see {{sec-comid-svn}}                                | {{&SELF}} |
+|     554 | `text`              | tagged-pkix-base64-key-type, see {{sec-crypto-keys}}                 | {{&SELF}} |
+|     555 | `text`              | tagged-pkix-base64-cert-type, see {{sec-crypto-keys}}                | {{&SELF}} |
+|     556 | `text`              | tagged-pkix-base64-cert-path-type, see {{sec-crypto-keys}}           | {{&SELF}} |
+|     557 | `[int/text, bytes]` | tagged-thumbprint-type, see {{sec-common-hash-entry}}                | {{&SELF}} |
+| 558-559 | `any`               | Earmarked for CoRIM                                                  | {{&SELF}} |
+|     560 | `bytes`             | $raw-value-type-choice, see {{sec-comid-raw-value-types}}            | {{&SELF}} |
+| 561-599 | `any`               | Earmarked for CoRIM                                                  | {{&SELF}} |
 
 Tags designated as "Earmarked for CoRIM" can be reassigned by IANA based on advice from the designated expert for the CBOR Tags registry.
 


### PR DESCRIPTION
xml2rfc laments about an absurd link that is created because square brackets are not escaped in an entry of the CBOR tag registration table.