### PR TITLE
Issue #78

### DIFF
--- a/cddl/domain-type-choice.cddl
+++ b/cddl/domain-type-choice.cddl
@@ -1,3 +1,4 @@
 $domain-type-choice /= uint
 $domain-type-choice /= text
 $domain-type-choice /= tagged-uuid-type
+$domain-type-choice /= tagged-oid-type

--- a/cddl/examples/comid-domain-mem.diag
+++ b/cddl/examples/comid-domain-mem.diag
@@ -1,0 +1,114 @@
+/ concise-mid-tag / {
+    / comid.tag-identity / 1 : {
+    / comid.tag-id / 0 : h'1EACD596F4A34FB699BFAEB58E0A4E47'
+  },
+  / comid.linked-tags / 3 : [ {
+    / comid.linked-tag-id / 0 : h'97F5A7071C6F438F877A4A020780EBE9',
+      / comid.tag-rel / 1 : / comid.supplements / 0
+  }
+  ],
+  / triples / 4 : {
+    / membership-triples / 5 : [
+      [ / domain - text / "XYZ_Root-of-trust",
+        [
+          / environment-map / {
+            / ** A Root of Trust module ** /
+            / comid.class / 0 : {
+                / comid.class-id / 0 :
+                  / tagged-oid-type / 111(h'0607517B010F6201'), / 2.1.123.1.15.98.1 /
+                / comid.vendor / 1 : "XYZ.example"
+            }
+          }
+        ]
+      ],
+      [ / domain - int / 1,
+        [
+          / environment-map / {
+            / ** Layer 1 loader module 1 ** /
+            / comid.class / 0 : {
+                / comid.class-id / 0 :
+                  / tagged-oid-type / 111(h'0607517B010F0801'), / 2.1.123.1.15.8.1 /
+                / comid.vendor / 1 : "LoadInc.example",
+                / comid.layer / 3 : 1
+            }
+          },
+          / environment-map / {
+            / ** Layer 1 loader module 2 ** /
+            / comid.class / 0 : {
+              / comid.class-id / 0 :
+                / tagged-oid-type / 111(h'0607517B010F0802'), / 2.1.123.1.15.8.2 /
+              / comid.vendor / 1 : "LoadInc.example",
+              / comid.layer / 3 : 1
+            }
+          }
+        ]
+      ],
+      [ / domain - text / "L1-extension",
+        [
+          / environment-map / {
+            / ** L1 Extension module 1 ** /
+            / comid.class / 0 : {
+              / comid.class-id / 0 :
+                / tagged-oid-type / 111(h'0607517B010F0903'), / 2.1.123.1.15.9.3 /
+              / comid.vendor / 1 : "LoadInc.example",
+              / comid.layer / 3 : 1
+            }
+          }
+        ]
+      ],
+      [ / domain - tagged-uuid-type / 37(
+              h'67b28b6c34cc40a19117ab5b05911e37'
+            ),
+        [
+          / environment-map / {
+            / ** Layer 2 design module 1 ** /
+            / comid.class / 0 : {
+                / comid.class-id / 0 :
+                  / tagged-oid-type / 111(h'0607517B010F0401'), /  2.1.123.1.15.4.1 /
+                / comid.vendor / 1 : "FPGAsRuS.example",
+                / comid.layer / 3 : 2
+            }
+          },
+          / environment-map / {
+            / ** Layer 2 design module 2 ** /
+            / comid.class / 0 : {
+              / comid.class-id / 0 :
+                / tagged-oid-type / 111(h'0607517B010F0402'), / 2.1.123.1.15.4.2 /
+              / comid.vendor / 1 : "FPGAsRuS.example",
+              / comid.layer / 3 : 2
+            }
+          },
+          / environment-map / {
+            / ** Layer 2 design module 3 ** /
+            / comid.class / 0 : {
+              / comid.class-id / 0 :
+                / tagged-oid-type / 111(h'0607517B010F0403'), / 2.1.123.1.15.4.3 /
+              / comid.vendor / 1 : "FPGAsRuS.example",
+              / comid.layer / 3 : 2
+            }
+          }
+        ]
+      ],
+      [ / domain - tagged-oid-type / 111(h'6086480186F84D010F0401'), / 2.16.840.1.113741.1.15.4.1 /
+        [
+          / environment-map / {
+            / ** ISV App module 1 ** /
+            / comid.class / 0 : {
+              / comid.class-id / 0 :
+                / tagged-oid-type / 111(h'0607517B010F046301'), / 2.1.123.1.15.4.99.1 /
+              / comid.vendor / 1 : "ISV-App.example"
+            }
+          },
+          / environment-map / {
+            / ** ISV App module 2 ** /
+            / comid.class / 0 : {
+              / comid.class-id / 0 :
+                / tagged-oid-type / 111(h'0607517B010F046302'), / 2.1.123.1.15.4.99.2 /
+              / comid.vendor / 1 : "ISV-App.example"
+            }
+          }
+        ]
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
Added tagged-oid-type to $domain-id-type-choice and examples that exercises domain names using all 4 supported domain id types.