### PR TITLE
Adds crypto key measurement type

### DIFF
--- a/cddl/examples/comid-4.diag
+++ b/cddl/examples/comid-4.diag
@@ -1,0 +1,33 @@
+/ concise-mid-tag / {
+  / comid.tag-identity / 1 : {
+    / comid.tag-id / 0 : h'3f06af63a93c11e4979700505690773f'
+  },
+  / comid.triples / 4 : {
+    / reference-triples / 0 : [ 
+      / reference-triple-record / [
+        / environment-map / {
+          / class / 0 : {
+            / class-id / 0 :
+              / tagged-uuid-type / 37(
+                h'67b28b6c34cc40a19117ab5b05911e37'
+              ),
+            / vendor / 1 : "ACME Inc.",
+            / model / 2 : "ACME RoadRunner",
+            / layer / 3 : 1
+          }
+        },
+        / measurement-map / {
+          / mval / 1 : {
+            / cryptokeys / 12 : [
+              / tagged-pkix-base64-key-type / 554("base64_key_ACME_MAX"),
+              / tagged-pkix-base64-cert-type / 555("base64_cert_ACME_MAX"),
+              / tagged-pkix-base64-cert-path-type / 556("base64_cert_path_ACME_MAX")
+            ]
+          }
+        }
+      ]
+    ]
+  }
+}
+
+    

--- a/cddl/measurement-values-map.cddl
+++ b/cddl/measurement-values-map.cddl
@@ -13,5 +13,6 @@ measurement-values-map = non-empty<{
   ? &(ueid: 9) => ueid-type
   ? &(uuid: 10) => uuid-type
   ? &(name: 11) => text
+  ? &(cryptokeys: 12) => [ + $crypto-key-type-choice ]
   * $$measurement-values-map-extension
 }>

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -941,7 +941,7 @@ The following describes each member of the `measurement-values-map`.
 
 * `cryptokeys` (index 12): identifies cryptographic keys that are protected by the Target Environment
   See {{sec-crypto-keys}} for the supported formats.
-  An Attesting Environment determines that keys are protected as part of Claims Collection.
+  An Attesting Environment determines that keys are protected as part of Claims collection.
   Appraisal verifies that, for each value in `cryptokeys`, there is a matching Reference Value entry.
 
 ###### Version {#sec-comid-version}

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1654,7 +1654,7 @@ are compared with the bytes following the CBOR tag from the Accepted Claims Set 
 If the byte strings match, and there is another array entry,
 then the next entry from the Reference Values array is likewise
 compared with the next entry of the Accepted Claims Set array.
-If all entrys of the Reference Values array matches a corresponding entry in the Accepted Claims Set array, then the `cryptokeys` Reference Value matches.
+If all entries of the Reference Values array match a corresponding entry in the Accepted Claims Set array, then the `cryptokeys` Reference Value matches.
 Otherwise, `cryptokeys` does not match.
 
 ##### Handling of new tags

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -940,7 +940,7 @@ The following describes each member of the `measurement-values-map`.
 * `name` (index 11): a name associated with the measured environment.
 
 * `cryptokeys` (index 12): identifies cryptographic keys that are protected by the Target Environment
-  See {{sec-crypto-keys}}.
+  See {{sec-crypto-keys}} for the supported formats.
   An Attesting Environment determines that keys are protected as part of Claims Collection.
   Appraisal verifies that, for each value in `cryptokeys`, there is a matching Reference Value entry.
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -885,6 +885,10 @@ environment. Depending on the context (triple) in which they are found,
 elements in a `measurement-values-map` can represent class or instance
 measurements. Note that some of the elements have instance scope only.
 
+Measurement values may support use cases beyond Verifier appraisal.
+Typically, a Relying Party determines if additional processing is desirable
+and whether the processing is applied by the Verifier or the Relying Party.
+
 ~~~ cddl
 {::include cddl/measurement-values-map.cddl}
 ~~~
@@ -934,6 +938,11 @@ The following describes each member of the `measurement-values-map`.
   {{sec-common-uuid}}.
 
 * `name` (index 11): a name associated with the measured environment.
+
+* `cryptokeys` (index 12): identifies cryptographic keys that are protected by the Target Environment
+  See {{sec-crypto-keys}}.
+  An Attesting Environment determines that keys are protected as part of Claims Collection.
+  Appraisal verifies that, for each value in `cryptokeys`, there is a matching Reference Value entry.
 
 ###### Version {#sec-comid-version}
 
@@ -1631,6 +1640,21 @@ there needs to be a mask at key 5). Should we have a Reference Value of this
 which stores [expect-raw-value raw-value-mask] in an array?
 
 [^issue]: Content missing. Tracked at https://github.com/ietf-rats-wg/draft-ietf-rats-corim/issues/71
+
+##### Comparison for cryptokeys entries
+
+The value stored under `measurement-values-map` key 12 is an array of `$crypto-key-type-choice` entries. `$crypto-key-type-choice` entries are CBOR tagged values.
+The array contains one or more entries in sequence.
+
+The CBOR tag of the first entry of the Reference Value `cryptokeys` array is compared with
+the CBOR tag of the first entry of the Accepted Claims Set `cryptokeys` value.
+If the CBOR tags match, then the bytes following the CBOR tag from the Reference Value entry
+are compared with the bytes following the CBOR tag from the Accepted Claims Set entry.
+If the byte strings match, and there is another array entry,
+then the next entry from the Reference Values array is likewise
+compared with the next entry of the Accepted Claims Set array.
+If all entrys of the Reference Values array matches a corresponding entry in the Accepted Claims Set array, then the `cryptokeys` Reference Value matches.
+Otherwise, `cryptokeys` does not match.
 
 ##### Handling of new tags
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1642,7 +1642,7 @@ which stores [expect-raw-value raw-value-mask] in an array?
 
 [^issue]: Content missing. Tracked at https://github.com/ietf-rats-wg/draft-ietf-rats-corim/issues/71
 
-##### Comparison for cryptokeys entries
+##### Comparison for cryptokeys entries {#sec-cryptokeys-matching}
 
 The value stored under `measurement-values-map` key 12 is an array of `$crypto-key-type-choice` entries. `$crypto-key-type-choice` entries are CBOR tagged values.
 The array contains one or more entries in sequence.

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -943,6 +943,7 @@ The following describes each member of the `measurement-values-map`.
   See {{sec-crypto-keys}} for the supported formats.
   An Attesting Environment determines that keys are protected as part of Claims collection.
   Appraisal verifies that, for each value in `cryptokeys`, there is a matching Reference Value entry.
+Matching is described in {{sec-cryptokeys-matching}}.
 
 ###### Version {#sec-comid-version}
 


### PR DESCRIPTION
Issue #126  calls for a $crypto-key-type-choice measurement that isn't stereotyped for either identity or attestation, but can support a wide range of key usages. It also allows authorized-by context to be added and works with conditional endorsement.