### PR TITLE
updated wording for accepted claims set init

### DIFF
--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1445,8 +1445,6 @@ The Accepted Claims Set is initialized by copying Evidence claims from the authe
 
 {{sec-dice-spdm}} provides information on how DICE and SPDM Evidence is reformatted into CoMID schema compliant expressions before being added to the Accepted Claims Set.
 
-Other Evidence formats may require format translation before being added to the Accepted Claims Set.
-A CoRIM profile, see {{sec-corim-map}}, may be used to define an Evidence translation function.
 
 ## Accepted Claims Set extension using CoMID tags
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1441,14 +1441,12 @@ an error and stop validation processing.
 
 ### Accepted Claims Set Initialization
 
-The Accepted Claims Set is initialized by copying Evidence claims from the authenticated Attester's Target Environments
-into the Verifier's Accepted Claims Set.
+The Accepted Claims Set is initialized by copying Evidence claims from the authenticated Attester's Target Environments into the Verifier's Accepted Claims Set.
 
-{{sec-dice-spdm}} provides information on how DICE and SPDM Evidence is reformatted into CoMID schema compliant expressions
-before being added to the Accepted Claims Set.
+{{sec-dice-spdm}} provides information on how DICE and SPDM Evidence is reformatted into CoMID schema compliant expressions before being added to the Accepted Claims Set.
 
-Other Evidence formats may require format translation before being added to the Accepted Claims Set. A CoRIM profile,
-see {{sec-corim-map}}, may be used to define an Evidence translation function.
+Other Evidence formats may require format translation before being added to the Accepted Claims Set.
+A CoRIM profile, see {{sec-corim-map}}, may be used to define an Evidence translation function.
 
 ## Accepted Claims Set extension using CoMID tags
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1439,17 +1439,17 @@ If the merged measurement-value-map contains duplicate codepoints and the
 measurement values are not equivalent then the verifier SHALL report
 an error and stop validation processing.
 
-### Accepted Claims Set Initialisation
+### Accepted Claims Set Initialization
 
-The Accepted Claims Set is initialised with cryptographically verified Evidence
-from the Attestation Environments.
+The Accepted Claims Set is initialized by copying Evidence claims from the authenticated Attester's Target Environments
+into the Verifier's Accepted Claims Set. By default, all Attester claims are allowed, unless disallowed by Reference Claims
+that do not satisfy appraisal checks.
 
-> A CoRIM profile MUST describe:
->
-> * How evidence is converted to a format suitable for appraisal
+{{sec-dice-spdm}} provides information on how DICE and SPDM Evidence is reformatted into CoMID schema compliant expressions
+before being added to the Accepted Claims Set.
 
-{{sec-dice-spdm}} provides information on how evidence collected using
-DICE and SPDM is added to the Accepted Claims Set.
+Other Evidence formats may require format translation before being added to the Accepted Claims Set. A CoRIM profile,
+see {{sec-corim-map}}, may be used to define an Evidence translation function.
 
 ## Accepted Claims Set extension using CoMID tags
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1442,8 +1442,7 @@ an error and stop validation processing.
 ### Accepted Claims Set Initialization
 
 The Accepted Claims Set is initialized by copying Evidence claims from the authenticated Attester's Target Environments
-into the Verifier's Accepted Claims Set. By default, all Attester claims are allowed, unless disallowed by Reference Claims
-that do not satisfy appraisal checks.
+into the Verifier's Accepted Claims Set.
 
 {{sec-dice-spdm}} provides information on how DICE and SPDM Evidence is reformatted into CoMID schema compliant expressions
 before being added to the Accepted Claims Set.

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1443,6 +1443,9 @@ an error and stop validation processing.
 
 The Accepted Claims Set is initialized by copying Evidence claims from the authenticated Attester's Target Environments into the Verifier's Accepted Claims Set.
 
+Evidence formats may require format translation before being added to the Accepted Claims Set.
+If format translation is required, a CoRIM profile, see {{sec-corim-profile-types}}, defines an Evidence translation function.
+
 {{sec-dice-spdm}} provides information on how DICE and SPDM Evidence is reformatted into CoMID schema compliant expressions before being added to the Accepted Claims Set.
 
 


### PR DESCRIPTION
Fixes issue #128. Reworded to make it clear that Evidence is copied into the ACS by default.