### PR TITLE
Added crypto-key as an environment identifier

### DIFF
--- a/cddl/examples/comid-6.diag
+++ b/cddl/examples/comid-6.diag
@@ -1,0 +1,29 @@
+/ concise-mid-tag / {
+  / comid.tag-identity / 1 : {
+    / comid.tag-id / 0 : h'3f06af63a93c11e4979700505690773f'
+  },
+  / comid.entity / 2 : [ {
+    / comid.entity-name / 0 : "ACME Inc.",
+    / comid.reg-id / 1 : 32("https://acme.example"),
+    / comid.role / 2 : [ 0 ] / tag-creator /
+  } ],
+  / comid.triples / 4 : {
+    / comid.reference-triples / 0 : [ [
+      / environment-map / {
+        / comid.instance / 1 : / tagged-pkix-base64-key-type / 554("base64_key_X")
+      },
+      / measurement-map / {
+        / comid.mval / 1 : {
+          / comid.ver / 0 : {
+            / comid.version / 0 : "1.0.0",
+            / comid.version-scheme / 1 : 16384 / semver /
+          },
+          / comid.digests / 2 : [ [
+            / hash-alg-id / 1, / sha256 /
+            / hash-value / h'44aa336af4cb14a879432e53dd6571c7fa9bccafb75f488259262d6ea3a4d91b'
+          ] ]
+        }
+      }
+    ] ]
+  }
+}

--- a/cddl/instance-id-type-choice.cddl
+++ b/cddl/instance-id-type-choice.cddl
@@ -1,2 +1,3 @@
 $instance-id-type-choice /= tagged-ueid-type
 $instance-id-type-choice /= tagged-uuid-type
+$instance-id-type-choice /= $crypto-key-type-choice

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -811,10 +811,11 @@ The following describes each member of the `class-map`:
 
 ##### Instance {#sec-comid-instance}
 
-An instance carries a unique identifier that is reliably bound to an instance
-of the Attester.
+An instance carries a unique identifier that is reliably bound to a Target Environment
+that is an instance of the Attester.
 
-The types defined for an instance identifier are UEID or UUID.
+The types defined for an instance identifier are CBOR tagged expressions of
+UEID, UUID, or cryptographic key identifier.
 
 ~~~ cddl
 {::include cddl/instance-id-type-choice.cddl}


### PR DESCRIPTION
Adds $crypto-key-type-choice as a possible environment-map instance identifier.
Addresses Issue #146 