### PR TITLE
Describe case where env-map has class & instance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'json_pure'
-gem 'cddl', '>=0.9.1'
+gem 'cddl', ['>=0.9.1', '!=0.10.5' ]
 gem 'cbor-diag', '=0.8.1'

--- a/cddl/class-id-type-choice.cddl
+++ b/cddl/class-id-type-choice.cddl
@@ -1,3 +1,4 @@
 $class-id-type-choice /= tagged-oid-type
 $class-id-type-choice /= tagged-uuid-type
 $class-id-type-choice /= tagged-int-type
+$class-id-type-choice /= tagged-bytes

--- a/cddl/condition-triple-record.cddl
+++ b/cddl/condition-triple-record.cddl
@@ -1,0 +1,4 @@
+condition-triple-record = [
+  environment-map
+  measurement-map
+]

--- a/cddl/condition-triple-record.cddl
+++ b/cddl/condition-triple-record.cddl
@@ -1,4 +1,0 @@
-condition-triple-record = [
-  environment-map
-  measurement-map
-]

--- a/cddl/corim-frags.mk
+++ b/cddl/corim-frags.mk
@@ -15,6 +15,7 @@ COMID_FRAGS += crypto-key-type-choice.cddl
 COMID_FRAGS += domain-dependency-triple-record.cddl
 COMID_FRAGS += domain-membership-triple-record.cddl
 COMID_FRAGS += mec-endorsement-triple-record.cddl
+COMID_FRAGS += condition-triple-record.cddl
 COMID_FRAGS += domain-type-choice.cddl
 COMID_FRAGS += endorsed-triple-record.cddl
 COMID_FRAGS += entity-map.cddl

--- a/cddl/corim-frags.mk
+++ b/cddl/corim-frags.mk
@@ -15,7 +15,6 @@ COMID_FRAGS += crypto-key-type-choice.cddl
 COMID_FRAGS += domain-dependency-triple-record.cddl
 COMID_FRAGS += domain-membership-triple-record.cddl
 COMID_FRAGS += mec-endorsement-triple-record.cddl
-COMID_FRAGS += condition-triple-record.cddl
 COMID_FRAGS += domain-type-choice.cddl
 COMID_FRAGS += endorsed-triple-record.cddl
 COMID_FRAGS += entity-map.cddl

--- a/cddl/corim-frags.mk
+++ b/cddl/corim-frags.mk
@@ -41,6 +41,7 @@ COMID_FRAGS += tag-identity-map.cddl
 COMID_FRAGS += tag-rel-type-choice.cddl
 COMID_FRAGS += tag-version-type.cddl
 COMID_FRAGS += tagged-int.cddl
+COMID_FRAGS += tagged-bytes.cddl
 COMID_FRAGS += triples-map.cddl
 COMID_FRAGS += ueid.cddl
 COMID_FRAGS += uuid.cddl

--- a/cddl/corim-frags.mk
+++ b/cddl/corim-frags.mk
@@ -14,6 +14,7 @@ COMID_FRAGS += coswid-triple-record.cddl
 COMID_FRAGS += crypto-key-type-choice.cddl
 COMID_FRAGS += domain-dependency-triple-record.cddl
 COMID_FRAGS += domain-membership-triple-record.cddl
+COMID_FRAGS += mec-endorsement-triple-record.cddl
 COMID_FRAGS += domain-type-choice.cddl
 COMID_FRAGS += endorsed-triple-record.cddl
 COMID_FRAGS += entity-map.cddl

--- a/cddl/examples/comid-4.diag
+++ b/cddl/examples/comid-4.diag
@@ -18,7 +18,7 @@
         },
         / measurement-map / {
           / mval / 1 : {
-            / cryptokeys / 12 : [
+            / cryptokeys / 13 : [
               / tagged-pkix-base64-key-type / 554("base64_key_ACME_MAX"),
               / tagged-pkix-base64-cert-type / 555("base64_cert_ACME_MAX"),
               / tagged-pkix-base64-cert-path-type / 556("base64_cert_path_ACME_MAX")

--- a/cddl/examples/comid-opaque-instance-id.cddl
+++ b/cddl/examples/comid-opaque-instance-id.cddl
@@ -1,0 +1,26 @@
+/ concise-mid-tag / {
+  / comid.tag-identity / 1 : {
+    / comid.tag-id / 0 : h'3f06af63a93c11e4979700505690773f'
+  },
+  / comid.entity / 2 : [ {
+    / comid.entity-name / 0 : "ACME Inc.",
+    / comid.reg-id / 1 : 32("https://acme.example"),
+    / comid.role / 2 : [ 0 ] / tag-creator /
+  } ],
+  / comid.triples / 4 : {
+    / comid.reference-triples / 0 : [ [
+      / environment-map / {
+        / comid.instance / 1 : / e.g., SEV-SNP CHIP_ID / 560(
+          h'9f71ec4d223f4f899d532ed6ff6ecbbb4a62cb386ba24c204c9371ce5e3b9291713fe96b9b413d8842968ebb1fa4cf1920d0c5e9f872776a1e826f2851ecdb47')
+      },
+      / measurement-map / {
+        / comid.mval / 1 : {
+          / comid.ver / 0 : {
+            / comid.version / 0 : "1.0.0",
+            / comid.version-scheme / 1 : 16384 / semver /
+          },
+        }
+      }
+    ] ]
+  }
+}

--- a/cddl/group-id-type-choice.cddl
+++ b/cddl/group-id-type-choice.cddl
@@ -1,1 +1,2 @@
 $group-id-type-choice /= tagged-uuid-type
+$group-id-type-choice /= tagged-bytes

--- a/cddl/instance-id-type-choice.cddl
+++ b/cddl/instance-id-type-choice.cddl
@@ -1,3 +1,4 @@
 $instance-id-type-choice /= tagged-ueid-type
 $instance-id-type-choice /= tagged-uuid-type
 $instance-id-type-choice /= $crypto-key-type-choice
+$instance-id-type-choice /= tagged-bytes

--- a/cddl/measurement-values-map.cddl
+++ b/cddl/measurement-values-map.cddl
@@ -13,6 +13,6 @@ measurement-values-map = non-empty<{
   ? &(ueid: 9) => ueid-type
   ? &(uuid: 10) => uuid-type
   ? &(name: 11) => text
-  ? &(cryptokeys: 12) => [ + $crypto-key-type-choice ]
+  ? &(cryptokeys: 13) => [ + $crypto-key-type-choice ]
   * $$measurement-values-map-extension
 }>

--- a/cddl/mec-endorsement-triple-record.cddl
+++ b/cddl/mec-endorsement-triple-record.cddl
@@ -1,4 +1,4 @@
 multi-env-conditional-endorsement-triple-record = [
-  conds: [ + stateful-environment-record ]
+  conds: [ + condition-triple-record ]
   actions: [ + stateful-environment-record ]
 ]

--- a/cddl/mec-endorsement-triple-record.cddl
+++ b/cddl/mec-endorsement-triple-record.cddl
@@ -1,4 +1,4 @@
 multi-env-conditional-endorsement-triple-record = [
-  conds: [ + condition-triple-record ]
-  actions: [ + stateful-environment-record ]
+  conds: [ + stateful-environment-record ]
+  endorsements: [ + endorsed-triple-record ]
 ]

--- a/cddl/mec-endorsement-triple-record.cddl
+++ b/cddl/mec-endorsement-triple-record.cddl
@@ -1,4 +1,4 @@
-multi-env-conditional-endorsement-triple-record = [
+mec-endorsement-triple-record = [
   conds: [ + stateful-environment-record ]
   endorsements: [ + endorsed-triple-record ]
 ]

--- a/cddl/mec-endorsement-triple-record.cddl
+++ b/cddl/mec-endorsement-triple-record.cddl
@@ -1,0 +1,4 @@
+multi-env-conditional-endorsement-triple-record = [
+  conds: [ + stateful-environment-record ]
+  actions: [ + stateful-environment-record ]
+]

--- a/cddl/raw-value.cddl
+++ b/cddl/raw-value.cddl
@@ -1,4 +1,3 @@
-tagged-bytes = #6.560(bytes)
 $raw-value-type-choice /= tagged-bytes
 
 raw-value-mask-type = bytes

--- a/cddl/tagged-bytes.cddl
+++ b/cddl/tagged-bytes.cddl
@@ -1,0 +1,1 @@
+tagged-bytes = #6.560(bytes)

--- a/cddl/triples-map.cddl
+++ b/cddl/triples-map.cddl
@@ -17,5 +17,7 @@ triples-map = non-empty<{
     [ + conditional-endorsement-series-triple-record ]
   ? &(conditional-endorsement-triples: 9) =>
     [ + conditional-endorsement-triple-record ]
+  ? &(mec-endorsement-triples: 10) =>
+    [ + multi-env-conditional-endorsement-triple-record ]
   * $$triples-map-extension
 }>

--- a/cddl/triples-map.cddl
+++ b/cddl/triples-map.cddl
@@ -19,7 +19,7 @@ triples-map = non-empty<{
     [ + conditional-endorsement-triple-record ]
   ? &(mec-endorsement-triples: 10) =>
     [ + multi-env-conditional-endorsement-triple-record ]
-  ? &(condition-triples: 11) = 
+  ? &(condition-triples: 11) =>
     [ + condition-triple-record ]
   * $$triples-map-extension
 }>

--- a/cddl/triples-map.cddl
+++ b/cddl/triples-map.cddl
@@ -19,5 +19,7 @@ triples-map = non-empty<{
     [ + conditional-endorsement-triple-record ]
   ? &(mec-endorsement-triples: 10) =>
     [ + multi-env-conditional-endorsement-triple-record ]
+  ? &(condition-triples: 11) = 
+    [ + condition-triple-record ]
   * $$triples-map-extension
 }>

--- a/cddl/triples-map.cddl
+++ b/cddl/triples-map.cddl
@@ -18,6 +18,6 @@ triples-map = non-empty<{
   ? &(conditional-endorsement-triples: 9) =>
     [ + conditional-endorsement-triple-record ]
   ? &(mec-endorsement-triples: 10) =>
-    [ + multi-env-conditional-endorsement-triple-record ]
+    [ + mec-endorsement-triple-record ]
   * $$triples-map-extension
 }>

--- a/cddl/triples-map.cddl
+++ b/cddl/triples-map.cddl
@@ -19,7 +19,5 @@ triples-map = non-empty<{
     [ + conditional-endorsement-triple-record ]
   ? &(mec-endorsement-triples: 10) =>
     [ + multi-env-conditional-endorsement-triple-record ]
-  ? &(condition-triples: 11) =>
-    [ + condition-triple-record ]
   * $$triples-map-extension
 }>

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -99,7 +99,7 @@ informative:
     seriesinfo: Version 1.0, Revision 0.19
     date: July 2020
     target: https://trustedcomputinggroup.org/wp-content/uploads/DICE-Layering-Architecture-r19_pub.pdf
-  IANA.concise-software-identifier: coswid-reg
+  IANA.coswid: coswid-reg
   SPDM:
     title: Security Protocol and Data Model (SPDM)
     author:
@@ -1137,14 +1137,6 @@ the object relates to the subject.
 {::include cddl/endorsed-triple-record.cddl}
 ~~~
 
-#### Condition Values Triple
-
-A Condition Values Triple defines a set of operational state of an environment. If the corresponding values defined in its `measurement-map` are found in an Accepted Claims Set, corresponding endorsed values defined in a `multi-env-conditional-endorsement-triple-record` can be added to that Accepted Claims Set.
-
-~~~ cddl
-{::include cddl/condition-triple-record.cddl}
-~~~
-
 #### Device Identity Triple {#sec-comid-triple-identity}
 
 A Device Identity triple relates one or more cryptographic keys to a device.
@@ -1208,10 +1200,8 @@ The semantics of the Multi-Environment Conditional (MEC) Endorsements Triple is 
 
 A `multi-env-conditional-endorsement-triple-record` has the following parameters:
 
-* `conds`: all target environments, along with a specific state, that need to match in order for the endorsement(s) to apply
-* `actions`: additional Endorsements are added to a current ACS maintained by a Verifier and that matches `conds` is augmented with another set of Endorsements
-
-All the entries in `cond` MUST match.
+* `conds`: all target environments, along with a specific state, that need to match `state-triples` entries in the ACS for the endorsement(s) to apply
+* `endorsements`: endorsements that are added to the ACS `state-triples` if all `conds` match.
 
 The order in which MEC Endorsement triples are evaluated is important: different sorting may produce different end-results in the computed ACS.
 
@@ -1221,9 +1211,6 @@ Notes:
 
 * In order to give the expected result, the condition must describe the expected context completely.
 * The scope of a single MEC triple encompasses an arbitrary amount of environments across all layers in an Attester.
-
-
-
 
 #### CoMID-CoSWID Linking Triple {#sec-comid-triple-coswid}
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1209,9 +1209,7 @@ The semantics of the Multi-Environment Conditional (MEC) Endorsements Triple is 
 A `multi-env-conditional-endorsement-triple-record` has the following parameters:
 
 * `conds`: all target environments, along with a specific state, that need to match in order for the endorsement(s) to apply
-* `actions`: TODO
-* `env`: the environment to which the endorsed value (conditionally) applies
-* `ends`: the endorsed value(s) associated with `env`
+* `actions`: additional Endorsements are added to a current ACS maintained by a Verifier and that matches `conds` is augmented with another set of Endorsements
 
 All the entries in `cond` MUST match.
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -749,6 +749,10 @@ The following describes each member of the `triples-map`:
   Endorsement based on the acceptance of a stateful environment. Described
   in {{sec-comid-triple-cond-end}}.
 
+* `multi-env-conditional-endorsement-triple-record` (index 10) Triples describing a series of Endorsement
+that are applicable based on the acceptance of a series of stateful environment records. Described
+in {{sec-comid-triple-mec-endorsement}}.
+
 #### Common Types
 
 ##### Environment

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -303,6 +303,16 @@ convention - e.g., {{Section 4.4.1.5 of -psa-token}}).
 {::include cddl/digest.cddl}
 ~~~
 
+### Tagged Bytes Type {#sec-common-tagged-bytes}
+
+An opaque, variable-length byte string.
+It can be used in different contexts: as an instance, class or group identifier in an `environment-map`; as a raw value measurement in a `measurement-values-map`.
+Its semantics is defined by the context in which it is found, and by the overarching CoRIM profile.
+
+~~~ cddl
+{::include cddl/tagged-bytes.cddl}
+~~~
+
 # Concise Reference Integrity Manifest (CoRIM) {#sec-corim}
 
 A CoRIM is a collection of tags and related metadata as described below.
@@ -821,7 +831,7 @@ An instance carries a unique identifier that is reliably bound to a Target Envir
 that is an instance of the Attester.
 
 The types defined for an instance identifier are CBOR tagged expressions of
-UEID, UUID, or cryptographic key identifier.
+UEID, UUID, variable-length opaque byte string, or cryptographic key identifier.
 
 ~~~ cddl
 {::include cddl/instance-id-type-choice.cddl}
@@ -833,7 +843,7 @@ A group carries a unique identifier that is reliably bound to a group of
 Attesters, for example when a number of Attester are hidden in the same
 anonymity set.
 
-The type defined for a group identified is UUID.
+The types defined for a group identified are UUID and variable-length opaque byte string.
 
 ~~~ cddl
 {::include cddl/group-id-type-choice.cddl}
@@ -1045,7 +1055,7 @@ Raw value measurements are typically vendor defined values that are checked by V
 for consistency only, since the security relevance is opaque to Verifiers.
 
 There are two parts to a `raw-value-group`, a measurement and an optional mask.
-The default raw value measurement is a CBOR tagged `bstr`.
+The default raw value measurement is of type `tagged-bytes` ({{sec-common-tagged-bytes}}).
 Additional raw value types can be defined, but must be CBOR tagged so that parsers can distinguish
 between the various semantics of type values.
 
@@ -1953,9 +1963,9 @@ IANA is requested to allocate the following tags in the "CBOR Tags" registry {{!
 |     555 | `text`              | tagged-pkix-base64-cert-type, see {{sec-crypto-keys}}                | {{&SELF}} |
 |     556 | `text`              | tagged-pkix-base64-cert-path-type, see {{sec-crypto-keys}}           | {{&SELF}} |
 |     557 | `[int/text, bytes]` | tagged-thumbprint-type, see {{sec-common-hash-entry}}                | {{&SELF}} |
-|     558 | `COSE_Key/ COSE_KeySet`   | tagged-cose-key-type, see {{sec-crypto-keys}}                        | {{&SELF}} |
+|     558 | `COSE_Key/ COSE_KeySet`   | tagged-cose-key-type, see {{sec-crypto-keys}}                  | {{&SELF}} |
 |     559 | `digest`            | tagged-cert-thumbprint-type, see {{sec-crypto-keys}}                 | {{&SELF}} |
-|     560 | `bytes`             | tagged-bytes, see {{sec-comid-raw-value-types}}                      | {{&SELF}} |
+|     560 | `bytes`             | tagged-bytes, see {{sec-common-tagged-bytes}}                        | {{&SELF}} |
 |     561 | `digest`            | tagged-cert-path-thumbprint-type, see  {{sec-crypto-keys}}           | {{&SELF}} |
 | 562-599 | `any`               | Earmarked for CoRIM                                                  | {{&SELF}} |
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1248,9 +1248,9 @@ applies to all measurements in the triple, including those in `measurement-value
 {::include cddl/conditional-endorsement-triple-record.cddl}
 ~~~
 
-#### Multi-Environment Conditional (MEC) Endorsements Triple {#sec-comid-triple-mec-endorsements}
+#### Multi-Environment Conditional (MEC) Endorsement Triple {#sec-comid-triple-mec-endorsement}
 
-The semantics of the Multi-Environment Conditional (MEC) Endorsements Triple is as follows:
+The semantics of the Multi-Environment Conditional (MEC) Endorsement Triple is as follows:
 
 > "IF accepted state matches all `conds` values, THEN every `endorsements` value is added to the accepted state"
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1214,8 +1214,7 @@ matched.
 The series object is an array of `conditional-series-record` that has both Reference and Endorsed Values.
 Each `conditional-series-record` record is evaluated in the order it appears in the series array.
 The Endorsed Values are accepted if the series condition in a `conditional-series-record` matches the ACS.
-The first `conditional-series-record` that successfully matches an ACS Entry terminates 
-the matching and the corresponding Endorsed Values are accepted.
+The first `conditional-series-record` that successfully matches an ACS Entry terminates the matching and the corresponding Endorsed Values are accepted.
 If none of the series conditions match an ACS Entry, the triple is not matched,
 and no Endorsed values are accepted.
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1252,7 +1252,7 @@ applies to all measurements in the triple, including those in `measurement-value
 
 The semantics of the Multi-Environment Conditional (MEC) Endorsements Triple is as follows:
 
-> "IF accepted state matches the `cond` value, THEN `env` is associated with the endorsed value(s) `ends`."
+> "IF accepted state matches all `conds` values, THEN every `endorsements` value is added to the accepted state"
 
 ~~~ cddl
 {::include cddl/mec-endorsement-triple-record.cddl}

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1137,7 +1137,7 @@ the object relates to the subject.
 {::include cddl/endorsed-triple-record.cddl}
 ~~~
 
-#### Condition Values Triple 
+#### Condition Values Triple
 
 A Condition Values Triple defines a set of operational state of an environment. If the corresponding values defined in its `measurement-map` are found in an Accepted Claims Set, corresponding endorsed values defined in a `multi-env-conditional-endorsement-triple-record` can be added to that Accepted Claims Set.
 
@@ -1209,7 +1209,7 @@ The semantics of the Multi-Environment Conditional (MEC) Endorsements Triple is 
 A `multi-env-conditional-endorsement-triple-record` has the following parameters:
 
 * `conds`: all target environments, along with a specific state, that need to match in order for the endorsement(s) to apply
-* `actions`: TODO 
+* `actions`: TODO
 * `env`: the environment to which the endorsed value (conditionally) applies
 * `ends`: the endorsed value(s) associated with `env`
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -807,7 +807,7 @@ needed.
 The following describes each member of the `class-map`:
 
 * `class-id` (index 0): Identifies the environment via a well-known identifier.
-  Typically, `class-id` is an object identifier (OID) or universally unique
+  Typically, `class-id` is an object identifier (OID) variable-length opaque byte string ({{sec-common-tagged-bytes}}) or universally unique
   identifier (UUID). Use of this attribute is preferred.
 
 * `vendor` (index 1): Identifies the entity responsible for choosing values for
@@ -832,7 +832,7 @@ An instance carries a unique identifier that is reliably bound to a Target Envir
 that is an instance of the Attester.
 
 The types defined for an instance identifier are CBOR tagged expressions of
-UEID, UUID, variable-length opaque byte string, or cryptographic key identifier.
+UEID, UUID, variable-length opaque byte string ({{sec-common-tagged-bytes}}), or cryptographic key identifier.
 
 ~~~ cddl
 {::include cddl/instance-id-type-choice.cddl}
@@ -844,7 +844,7 @@ A group carries a unique identifier that is reliably bound to a group of
 Attesters, for example when a number of Attester are hidden in the same
 anonymity set.
 
-The types defined for a group identified are UUID and variable-length opaque byte string.
+The types defined for a group identified are UUID and variable-length opaque byte string ({{sec-common-tagged-bytes}}).
 
 ~~~ cddl
 {::include cddl/group-id-type-choice.cddl}

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -308,7 +308,7 @@ convention - e.g., {{Section 4.4.1.5 of -psa-token}}).
 An opaque, variable-length byte string.
 It can be used in different contexts: as an instance, class or group identifier in an `environment-map`; as a raw value measurement in a `measurement-values-map`.
 Its semantics are defined by the context in which it is found, and by the overarching CoRIM profile.
-When used as an identifier the responsible allocator entity SHOULD ensure uniqueness.
+When used as an identifier the responsible allocator entity SHOULD ensure uniqueness within the usage scope.
 
 ~~~ cddl
 {::include cddl/tagged-bytes.cddl}

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -308,6 +308,7 @@ convention - e.g., {{Section 4.4.1.5 of -psa-token}}).
 An opaque, variable-length byte string.
 It can be used in different contexts: as an instance, class or group identifier in an `environment-map`; as a raw value measurement in a `measurement-values-map`.
 Its semantics is defined by the context in which it is found, and by the overarching CoRIM profile.
+When used as an identifier uniqueness SHOULD be guaranteed by the responsible allocator entity.
 
 ~~~ cddl
 {::include cddl/tagged-bytes.cddl}

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -307,7 +307,7 @@ convention - e.g., {{Section 4.4.1.5 of -psa-token}}).
 
 An opaque, variable-length byte string.
 It can be used in different contexts: as an instance, class or group identifier in an `environment-map`; as a raw value measurement in a `measurement-values-map`.
-Its semantics is defined by the context in which it is found, and by the overarching CoRIM profile.
+Its semantics are defined by the context in which it is found, and by the overarching CoRIM profile.
 When used as an identifier the responsible allocator entity SHOULD ensure uniqueness.
 
 ~~~ cddl

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -957,7 +957,7 @@ The following describes each member of the `measurement-values-map`.
 
 * `name` (index 11): a name associated with the measured environment.
 
-* `cryptokeys` (index 12): identifies cryptographic keys that are protected by the Target Environment
+* `cryptokeys` (index 13): identifies cryptographic keys that are protected by the Target Environment
   See {{sec-crypto-keys}} for the supported formats.
   An Attesting Environment determines that keys are protected as part of Claims collection.
   Appraisal verifies that, for each value in `cryptokeys`, there is a matching Reference Value entry.

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1669,9 +1669,9 @@ of the ACS `environment-map`.
 If there are no candidate entries then the triple containing the stateful environment does not match.
 
 A stateful environment `environment-map` is a subset of an ACS entry `environment-map`
-if each field which is present in the stateful environment `environment-map`
-(for example `class`, `instance` etc.)
-is also present in the ACS entry, and the CBOR encoded field values in the stateful environment and
+if each field (for example `class`, `instance` etc.) which is present in the
+stateful environment `environment-map` is also present in the ACS entry,
+and the CBOR encoded field values in the stateful environment and
 ACS entry are binary identical.
 If a field is not present in the stateful environment `environment-map` then the presence of,
 and value of, the corresponding ACS entry field does not affect whether the `environment-map`s are subsets.

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1656,14 +1656,17 @@ A Reference Value consists of an `environment-map` plus a `measurement-map`. In 
 Reference Values are represented more compactly by letting one `environment-map`
 apply to multiple `measurement-map`s.
 
-The Verifier first looks for entries in the Accepted Claims Set with the same
-`environment-map` as the Reference Value. These are the candidate claims. If there are
+The Verifier first looks for entries in the Accepted Claims Set with an
+`environment-map` which is compatible with the Reference Value.
+These are the candidate claims. If there are
 no candidate claims then the Reference Value does not match.
 
-A Verifier SHALL compare two `environment-map`s using a binary comparison of the CBOR
-encoded objects.
+An ACS entry has a compatible `environment-map` if each field which is present
+in the Reference Value environment-map (for example `class`, `instance` etc.)
+is also present in the ACS entry, and the CBOR encoded field values in the Reference Value and ACS entry are binary identical.
+If a field is not present in the Reference value then the presence of, and value of, the corresponding ACS entry field does not affect whether the `environment-map`s are compatible.
 
-A Verifier SHOULD convert `environment-map` into a form which meets CBOR Core
+A Verifier SHOULD convert `environment-map` fields into a form which meets CBOR Core
 Deterministic Encoding Requirements {{-cbor}} before performing the binary comparison.
 
 If the Reference Value contains an `authorized-by` field then the Verifier

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1137,6 +1137,14 @@ the object relates to the subject.
 {::include cddl/endorsed-triple-record.cddl}
 ~~~
 
+#### Condition Values Triple 
+
+A Condition Values Triple defines a set of operational state of an environment. If the corresponding values defined in its `measurement-map` are found in an Accepted Claims Set, corresponding endorsed values defined in a `multi-env-conditional-endorsement-triple-record` can be added to that Accepted Claims Set.
+
+~~~ cddl
+{::include cddl/condition-triple-record.cddl}
+~~~
+
 #### Device Identity Triple {#sec-comid-triple-identity}
 
 A Device Identity triple relates one or more cryptographic keys to a device.
@@ -1185,6 +1193,39 @@ Evidence.
 ~~~ cddl
 {::include cddl/domain-membership-triple-record.cddl}
 ~~~
+
+
+
+#### Multi-Environment Conditional (MEC) Endorsements Triple {#sec-comid-triple-mec-endorsements}
+
+The semantics of the Multi-Environment Conditional (MEC) Endorsements Triple is as follows:
+
+> "IF accepted state matches the `cond` value, THEN `env` is associated with the endorsed value(s) `ends`."
+
+~~~ cddl
+{::include cddl/mec-endorsement-triple-record.cddl}
+~~~
+
+A `multi-env-conditional-endorsement-triple-record` has the following parameters:
+
+* `conds`: all target environments, along with a specific state, that need to match in order for the endorsement(s) to apply
+* `actions`: TODO 
+* `env`: the environment to which the endorsed value (conditionally) applies
+* `ends`: the endorsed value(s) associated with `env`
+
+All the entries in `cond` MUST match.
+
+The order in which MEC Endorsement triples are evaluated is important: different sorting may produce different end-results in the computed ACS.
+
+Therefore, the set of applicable MEC Endorsement triple MUST be topologically sorted based on the criterion that a MEC Endorsement triple is evaluated before another if its Target Environment and Endorsement pair is found in any of the stateful environments of the second triple.
+
+Notes:
+
+* In order to give the expected result, the condition must describe the expected context completely.
+* The scope of a single MEC triple encompasses an arbitrary amount of environments across all layers in an Attester.
+
+
+
 
 #### CoMID-CoSWID Linking Triple {#sec-comid-triple-coswid}
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1625,7 +1625,7 @@ If any `reference-triple-record` in the Reference Value triple does not match th
 An Endorser may use CoMID tags to publish Conditional Endorsements, which are added to the Accepted Claims Set only if specified conditions apply.
 This section describes the process performed by the Verifier to determine which Conditional Endorsements from the candidate CoMIDs should be added to the ACS.
 
-The verifier checks whether Conditional Endorsements are applicable by comparing Evidence in the Accepted Claims Set against expected values provided in `stateful-environment-record` object which are part of the triple.
+The verifier checks whether Conditional Endorsements are applicable by comparing Accepted Claims Set entries against expected values provided in `stateful-environment-record` object which are part of the triple.
 
 #### Processing Conditional Endorsement Triple
 
@@ -1652,9 +1652,9 @@ The second step stops if a match is detected.
 If the second step matches then the Verifier adds an Endorsement entry to the ACS.
 This endorsement is created from the `environment-map` field in `stateful-environment-record`, the `endv` field from the match detected in the second step and the authority which signed the tag containing the Conditional Endorsement Series Triple.
 
-#### Matching a stateful environment against the Accepted Claims Set {#sec-match-one-ref-val}
+#### Matching a stateful environment against the Accepted Claims Set {#sec-match-one-se}
 
-This section describes how a stateful environment is matched against Evidence in the Accepted Claims Set.
+This section describes how a stateful environment is matched against an Accepted Claims Set entry.
 If any part of the processing indicates that the stateful environment does not match then the remaining steps in this section are skipped for that stateful environment.
 
 A stateful environment consists of an `environment-map` plus a `measurement-map` which are processed separately.
@@ -1675,8 +1675,15 @@ The stateful environment entry is compared against each of the candidate entries
 If none of the candidate entries matches the stateful environment entry then the stateful environment does not match.
 
 For each of the candidate entries, the Verifier SHALL iterate over the codepoints which are present in the `measurement-values-map` field (referred to as the "MVM codepoints" below) within the stateful environment `measurement-map`.
+Each of the codepoints present in the stateful environment is compared againt the candidate entry.
 
-The algorithm used to match the MVM codepoints is described below.
+If any codepoint present in the stateful environment `measurement-values-map` doesn't match the same codepoint within the candidate entry then the stateful environment does not match.
+
+If all checks above have been performed successfully then the stateful environment matches.
+
+#### Matching a single codepoint in two measurement-value-maps {#sec-match-one-codepoint}
+
+The algorithm used to match the MVM codepoints is described in this section.
 The comparison performed depends on the value of the codepoint being compared and whether the `measurement-values-map` value associated with that codepoint is tagged.
 
 If the stateful environment `measurement-values-map` value is tagged with a CBOR tag {{-cbor}} then the Verifier MUST use the comparison algorithm associated with that tag.
@@ -1696,8 +1703,6 @@ If the values are not binary identical then the stateful environment does not ma
 
 Note that while specifications may extend the matching semantics using CBOR tags, there is no way to extend the matching semantics of codepoints.
 Any new codepoints requiring non-default comparison must add a CBOR tag to the Reference Value describing the desired behaviour.
-
-If all checks above have been performed successfully then the stateful environment matches.
 
 ##### Comparison for svn entries
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -308,7 +308,7 @@ convention - e.g., {{Section 4.4.1.5 of -psa-token}}).
 An opaque, variable-length byte string.
 It can be used in different contexts: as an instance, class or group identifier in an `environment-map`; as a raw value measurement in a `measurement-values-map`.
 Its semantics are defined by the context in which it is found, and by the overarching CoRIM profile.
-When used as an identifier the responsible allocator entity SHOULD ensure uniqueness within the usage scope.
+When used as an identifier the responsible allocator entity SHOULD ensure uniqueness within the context that it is used.
 
 ~~~ cddl
 {::include cddl/tagged-bytes.cddl}

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1186,32 +1186,6 @@ Evidence.
 {::include cddl/domain-membership-triple-record.cddl}
 ~~~
 
-
-
-#### Multi-Environment Conditional (MEC) Endorsements Triple {#sec-comid-triple-mec-endorsements}
-
-The semantics of the Multi-Environment Conditional (MEC) Endorsements Triple is as follows:
-
-> "IF accepted state matches the `cond` value, THEN `env` is associated with the endorsed value(s) `ends`."
-
-~~~ cddl
-{::include cddl/mec-endorsement-triple-record.cddl}
-~~~
-
-A `multi-env-conditional-endorsement-triple-record` has the following parameters:
-
-* `conds`: all target environments, along with a specific state, that need to match `state-triples` entries in the ACS for the endorsement(s) to apply
-* `endorsements`: endorsements that are added to the ACS `state-triples` if all `conds` match.
-
-The order in which MEC Endorsement triples are evaluated is important: different sorting may produce different end-results in the computed ACS.
-
-Therefore, the set of applicable MEC Endorsement triple MUST be topologically sorted based on the criterion that a MEC Endorsement triple is evaluated before another if its Target Environment and Endorsement pair is found in any of the stateful environments of the second triple.
-
-Notes:
-
-* In order to give the expected result, the condition must describe the expected context completely.
-* The scope of a single MEC triple encompasses an arbitrary amount of environments across all layers in an Attester.
-
 #### CoMID-CoSWID Linking Triple {#sec-comid-triple-coswid}
 
 A CoSWID triple relates reference measurements contained in one or more CoSWIDs
@@ -1273,6 +1247,30 @@ applies to all measurements in the triple, including those in `measurement-value
 ~~~ cddl
 {::include cddl/conditional-endorsement-triple-record.cddl}
 ~~~
+
+#### Multi-Environment Conditional (MEC) Endorsements Triple {#sec-comid-triple-mec-endorsements}
+
+The semantics of the Multi-Environment Conditional (MEC) Endorsements Triple is as follows:
+
+> "IF accepted state matches the `cond` value, THEN `env` is associated with the endorsed value(s) `ends`."
+
+~~~ cddl
+{::include cddl/mec-endorsement-triple-record.cddl}
+~~~
+
+A `multi-env-conditional-endorsement-triple-record` has the following parameters:
+
+* `conds`: all target environments, along with a specific state, that need to match `state-triples` entries in the ACS for the endorsement(s) to apply
+* `endorsements`: endorsements that are added to the ACS `state-triples` if all `conds` match.
+
+The order in which MEC Endorsement triples are evaluated is important: different sorting may produce different end-results in the computed ACS.
+
+Therefore, the set of applicable MEC Endorsement triple MUST be topologically sorted based on the criterion that a MEC Endorsement triple is evaluated before another if its Target Environment and Endorsement pair is found in any of the stateful environments of the second triple.
+
+Notes:
+
+* In order to give the expected result, the condition must describe the expected context completely.
+* The scope of a single MEC triple encompasses an arbitrary amount of environments across all layers in an Attester.
 
 ## Extensibility {#sec-extensibility}
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -308,7 +308,7 @@ convention - e.g., {{Section 4.4.1.5 of -psa-token}}).
 An opaque, variable-length byte string.
 It can be used in different contexts: as an instance, class or group identifier in an `environment-map`; as a raw value measurement in a `measurement-values-map`.
 Its semantics is defined by the context in which it is found, and by the overarching CoRIM profile.
-When used as an identifier uniqueness SHOULD be guaranteed by the responsible allocator entity.
+When used as an identifier the responsible allocator entity SHOULD ensure uniqueness.
 
 ~~~ cddl
 {::include cddl/tagged-bytes.cddl}

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1595,15 +1595,18 @@ format. Using a common format makes it easier to compare the field.
 In the Accepted Claims Set augmentation phase, a CoRIM Appraisal Context and an Evidence Appraisal Policy are used by the Verifier to find CoMID triples which match the Accepted Claims Set (ACS).
 Triples that specify an ACS matching condition will augment the ACS with Endorsements if the condition is met.
 
-Each triple is processed independently of other triples. However, the ACS state may change as a result of processing a triple.
+Each triple is processed independently of other triples.
+However, the ACS state may change as a result of processing a triple.
 If a triple condition does not match, then the Verifier continues to process other triples.
 
 ### Ordering of triple processing
 
 Triples interface with the ACS by either adding new ACS entries or by matching existing ACS entries before updating the ACS.
-Most triples use an `environment-map` field to select the AES entries to match or modify. This field may be contained in an explicit matching condition, such as `stateful-environment-record`.
+Most triples use an `environment-map` field to select the AES entries to match or modify.
+This field may be contained in an explicit matching condition, such as `stateful-environment-record`.
 
-The order of triples processing is important. Processing a triple may result in ACS modifications that affect matching behavior of other triples.
+The order of triples processing is important.
+Processing a triple may result in ACS modifications that affect matching behavior of other triples.
 
 The Verifier MUST ensure that a triple including a matching condition is processed after any other triple that modifies or adds an ACS entry with an `environment-map` that is in the matching condition.
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1645,77 +1645,87 @@ all Endorsements in the group are silently ignored.
 Each group is processed independently of other groups. If a group fails to match
 the Accepted Claims Set then this does not affect the processing of other groups.
 
-#### Matching a Reference Value against the Accepted Claims Set {#sec-match-one-ref-val}
+#### Matching a stateful environment against the Accepted Claims Set {#sec-match-one-ref-val}
 
-This section describes how a Reference Value is matched against Evidence in the Accepted
-Claims Set.
-If any part of the processing indicates that the Reference Value does not match then the remaining steps in this section are skipped for that group.
+[^issue]: There were two interpretations of the meaning of `Reference Value` and the adopted
+meaning does not match the version in the current text. I will submit a further PR to replace
+most uses of "Reference Value" in section 5 with "stateful environment".
+Tracked at https://github.com/ietf-rats-wg/draft-ietf-rats-corim/issues/178
 
-A Reference Value consists of an `environment-map` plus a `measurement-map`. In the
-`reference-triple-record` these are encoded together. In other triples multiple
-Reference Values are represented more compactly by letting one `environment-map`
-apply to multiple `measurement-map`s.
+This section describes how a stateful environment is matched against Evidence in the
+Accepted Claims Set.
+If any part of the processing indicates that the stateful environment does not match
+then the remaining steps in this section are skipped for that conditional endorsement.
 
-The Verifier first looks for entries in the Accepted Claims Set with an
-`environment-map` which is compatible with the Reference Value.
-These are the candidate claims. If there are
-no candidate claims then the Reference Value does not match.
+A stateful environment consists of an `environment-map` plus a `measurement-map`.
+In `conditional-endorsement-triple-record` and `mec-endorsement-triple-record` these are encoded together.
+In other triples multiple stateful environments are represented more compactly by
+letting one `environment-map` apply to multiple `measurement-map`s.
 
-An ACS entry has a compatible `environment-map` if each field which is present
-in the Reference Value environment-map (for example `class`, `instance` etc.)
-is also present in the ACS entry, and the CBOR encoded field values in the Reference Value and ACS entry are binary identical.
-If a field is not present in the Reference value then the presence of, and value of, the corresponding ACS entry field does not affect whether the `environment-map`s are compatible.
+The Verifier initialises its temporary `candidate entries` variable with all entries in the
+Accepted Claims Set (ACS) where the stateful enviromnment `environment-map` is a subset
+of the ACS `environment-map`.
 
-A Verifier SHOULD convert `environment-map` fields into a form which meets CBOR Core
-Deterministic Encoding Requirements {{-cbor}} before performing the binary comparison.
+If there are no candidate entries then the triple containing the stateful environment does not match.
 
-If the Reference Value contains an `authorized-by` field then the Verifier
-SHALL modify the candidate claims set to remove Claims whose `authorized-by`
-field does not contain one of the keys listed in the Reference Value
+A stateful environment `environment-map` is a subset of an ACS entry `environment-map`
+if each field which is present in the stateful environment `environment-map`
+(for example `class`, `instance` etc.)
+is also present in the ACS entry, and the CBOR encoded field values in the stateful environment and
+ACS entry are binary identical.
+If a field is not present in the stateful environment `environment-map` then the presence of,
+and value of, the corresponding ACS entry field does not affect whether the `environment-map`s are subsets.
+
+Before performing the binary comparison, a Verifier SHOULD convert `environment-map` fields into
+a form which meets CBOR Core Deterministic Encoding Requirements {{-cbor}}.
+
+If the stateful environment contains an `authorized-by` field then the Verifier
+SHALL modify the candidate entries to remove entries whose `authorized-by`
+field does not contain one of the keys listed in the stateful environment
 `authorized-by` field (see {{sec-authorized-by}} for more details).
-If all candidate claim entries are discarded by this step then the
-Reference Value does not match.
+If all candidate entries are discarded by this step then the
+stateful environment does not match.
 
 The Verifier SHALL iterate over the codepoints which are present in the
-`measurement-values-map` field within the Reference Value `measurement-values-map`.
-The Reference Value entry is compared against each of the candidate claims.
-If none of the candidate claims matches
-the Reference Value entry then the Reference Value does not match.
+`measurement-values-map` field within the stateful environment `measurement-values-map`.
+The stateful environment entry is compared against each of the candidate entries.
+If none of the candidate entries matches
+the stateful environment entry then the stateful environment does not match.
 
 The algorithm used to match the `measurement-values-map` entries
 is described below. The comparison performed depends on the type of
 field being compared.
 
-If the Reference Value `measurement-values-map` value is tagged with a CBOR
+If the stateful environment `measurement-values-map` value is tagged with a CBOR
 tag {{-cbor}} then the Verifier MUST use the comparison algorithm associated
 with that tag.
 
-If the Reference Value is not tagged then the Verifier MUST use the comparison
+If the stateful environment is not tagged then the Verifier MUST use the comparison
 algorithm associated with the `measurement-values-map` codepoint for the entry.
 
-This specification defines the matching algorithm for some CBOR tagged reference
-values, which is described in sub-sections below.
+This specification defines the matching algorithm for some CBOR tagged stateful environments,
+which is described in sub-sections below.
 
 A CoRIM profile may define additional tags and their matching algorithms.
 
-If the Verifier does not recognize the Reference Value CBOR tag value then
-the Reference Value does not match.
+If the Verifier does not recognize the stateful environment CBOR tag value then
+the stateful environment does not match.
 
-If the Reference Value is not tagged and the measurement-value-map key is a
+If the stateful environment is not tagged and the measurement-value-map key is a
 value with handling described in the sub-sections below,
 then the algorithm appropriate to that key is used to match the entries.
 
-If the Reference Value is not tagged, and the `measurement-values-map` key
+If the stateful environment is not tagged, and the `measurement-values-map` key
 is not a value described below, then the entries are compared
 using binary comparison of their CBOR encoded values. If the values
-are not binary identical then the Reference Value does not match.
+are not binary identical then the stateful environment does not match.
 
 Note that while specifications may extend the matching semantics using CBOR tags,
 there is no way to extend the matching semantics of keys.
 Any new keys requiring non-default comparison must add a CBOR tag to the
 Reference Value describing the desired behaviour.
 
-If all checks above have been performed successfully then the Reference Value
+If all checks above have been performed successfully then the stateful environment
 matches.
 
 ##### Comparison for svn entries

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1277,6 +1277,8 @@ Notes:
 * In order to give the expected result, the condition must describe the expected context completely.
 * The scope of a single MEC triple encompasses an arbitrary amount of environments across all layers in an Attester.
 
+There are scope-related questions that need to be answered.  ([^tracked-at] https://github.com/ietf-rats-wg/draft-ietf-rats-corim/issues/176)
+
 ## Extensibility {#sec-extensibility}
 
 The base CORIM schema is described using CDDL {{-cddl}} that can be extended

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -749,9 +749,10 @@ The following describes each member of the `triples-map`:
   Endorsement based on the acceptance of a stateful environment. Described
   in {{sec-comid-triple-cond-end}}.
 
-* `multi-env-conditional-endorsement-triple-record` (index 10) Triples describing a series of Endorsement
-that are applicable based on the acceptance of a series of stateful environment records. Described
-in {{sec-comid-triple-mec-endorsement}}.
+* `mec-endorsement-triple-record` (index 10) Triples describing a series of
+  Endorsement that are applicable based on the acceptance of a series of
+  stateful environment records. Described in
+  {{sec-comid-triple-mec-endorsement}}.
 
 #### Common Types
 
@@ -1262,7 +1263,7 @@ The semantics of the Multi-Environment Conditional (MEC) Endorsement Triple is a
 {::include cddl/mec-endorsement-triple-record.cddl}
 ~~~
 
-A `multi-env-conditional-endorsement-triple-record` has the following parameters:
+A `mec-endorsement-triple-record` has the following parameters:
 
 * `conds`: all target environments, along with a specific state, that need to match `state-triples` entries in the ACS for the endorsement(s) to apply
 * `endorsements`: endorsements that are added to the ACS `state-triples` if all `conds` match.

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1257,7 +1257,7 @@ applies to all measurements in the triple, including those in `measurement-value
 
 The semantics of the Multi-Environment Conditional (MEC) Endorsement Triple is as follows:
 
-> "IF accepted state matches all `conds` values, THEN every `endorsements` value is added to the accepted state"
+> "IF accepted state matches all `conds` values, THEN every  entry in the `endorsements` is added to the accepted state"
 
 ~~~ cddl
 {::include cddl/mec-endorsement-triple-record.cddl}


### PR DESCRIPTION
Enhance description of matching rules for `environment-map` to permit richer behavior when both `class` and `instance` fields are present.
This fixes issue #172 and is part of the solution to issue #173.
It also fixes #136 (removing the term "group") and #80.
It also fixes #175