### PR TITLE
editorial pass of §5 up to 5.3.2

### DIFF
--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1435,7 +1435,7 @@ For example, if the Evidence format is known in advance, CoRIMs using a profile 
 
 The selection process MUST yield at least one usable tag.
 
-Later stages will further select the CoRIMs appropriate to the Evidence Appraisal stage. TBC(tho)
+Later stages will further select the CoRIMs appropriate to the Evidence Appraisal stage.
 
 ### CoBOM Extraction
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1485,7 +1485,7 @@ The way cryptographic signature validation works depends on the specific Evidenc
 For instance, in DICE, a proof of liveness is carried out on the final key in the certificate chain (a.k.a., the alias certificate).
 If this is successful, a suitable certification path is looked up in the Appraisal Context, based on linking information obtained from the DeviceID certificate (see Section 9.2.1 of {{DICE.Layer}}).
 If a trusted root certificate is found, the usual X.509 certificate validation is performed.
-On the other hand, in PSA, the verification public key is looked up in the appraisal context using the `ueid` claim found in the PSA claims-set (see {{Section 4.2.1 of -psa-token}}).
+As a second example, in PSA {{-psa-token}} the verification public key is looked up in the appraisal context using the `ueid` claim found in the PSA claims-set.
 If found, COSE Sign1 verification is performed accordingly.
 
 Regardless of the specific integrity protection method used, the Evidence's integrity MUST be verified successfully.

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1482,7 +1482,7 @@ The Evidence collection generates protocol-specific data and transcripts that ar
 If Evidence is cryptographically signed, its validation is the first step in Appraisal.
 
 The way cryptographic signature validation works depends on the specific Evidence collection protocol being used.
-For instance, in DICE, a proof of liveness is carried out on the final key in the certificate chain.
+For instance, in DICE, a proof of liveness is carried out on the final key in the certificate chain (a.k.a., the alias certificate).
 If this is successful, a suitable certification path is looked up in the Appraisal Context, based on linking information obtained from the DeviceID certificate (see Section 9.2.1 of {{DICE.Layer}}).
 If a trusted root certificate is found, the usual X.509 certificate validation is performed.
 On the other hand, in PSA, the verification public key is looked up in the appraisal context using the `ueid` claim found in the PSA claims-set (see {{Section 4.2.1 of -psa-token}}).


### PR DESCRIPTION
* various reformatting
* edits for clarity & conciseness
* added missing "Evidence Appraisal" subsection
* removed "group" from the glossary because it wasn't used