### PR TITLE
integrity registers, misc wordsmithing 

### DIFF
--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1868,7 +1868,7 @@ Otherwise, `cryptokeys` does not match.
 
 ##### Comparison for Integrity Registers {#sec-cmp-integrity-registers}
 
-For each Integrity Register entry in the Reference Value, the Verifier will use the associated identifier (i.e., `integrity-register-id-type-choice`), to look up the matching Integrity Register entry in Evidence.
+For each Integrity Register entry in the Reference Value, the Verifier will use the associated identifier (i.e., `integrity-register-id-type-choice`) to look up the matching Integrity Register entry in Evidence.
 If no entry is found, the Reference Value does not match.
 Instead, if an entry is found, the digest comparison proceeds as defined in {{sec-cmp-digests}} after the cross product equivalence has been found according to {{sec-comid-integrity-registers}}.
 Note that it is not required for all the entries in Evidence to be used during matching: the Reference Value could consist of a subset of the device's register space. In TPM parlance, a TPM "quote" may report all PCRs in Evidence, while a Reference Value could describe a subset of PCRs.

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1870,7 +1870,7 @@ Otherwise, `cryptokeys` does not match.
 
 For each Integrity Register entry in the Reference Value, the Verifier will use the associated identifier (i.e., `integrity-register-id-type-choice`) to look up the matching Integrity Register entry in Evidence.
 If no entry is found, the Reference Value does not match.
-Instead, if an entry is found, the digest comparison proceeds as defined in {{sec-cmp-digests}} after the cross product equivalence has been found according to {{sec-comid-integrity-registers}}.
+Instead, if an entry is found, the digest comparison proceeds as defined in {{sec-cmp-digests}} after the cross-product equivalence has been found according to {{sec-comid-integrity-registers}}.
 Note that it is not required for all the entries in Evidence to be used during matching: the Reference Value could consist of a subset of the device's register space. In TPM parlance, a TPM "quote" may report all PCRs in Evidence, while a Reference Value could describe a subset of PCRs.
 
 ##### Handling of new tags

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1868,10 +1868,10 @@ Otherwise, `cryptokeys` does not match.
 
 ##### Comparison for Integrity Registers {#sec-cmp-integrity-registers}
 
-For each Integrity Register entry in the Reference Value, the Verifier will use the associated identifier to look up the matching Integrity Register entry in Evidence.
+For each Integrity Register entry in the Reference Value, the Verifier will use the associated identifier (i.e., `integrity-register-id-type-choice`), to look up the matching Integrity Register entry in Evidence.
 If no entry is found, the Reference Value does not match.
-Instead, if an entry is found, the digest comparison proceeds as defined in {{sec-cmp-digests}}.
-Note that it is not required for all the entries in Evidence to be used during matching: the Reference Value could consist of a "quote" (in TPM parlance) of just a subset of the register space.
+Instead, if an entry is found, the digest comparison proceeds as defined in {{sec-cmp-digests}} after the cross product equivalence has been found according to {{sec-comid-integrity-registers}}.
+Note that it is not required for all the entries in Evidence to be used during matching: the Reference Value could consist of a subset of the device's register space. In TPM parlance, a TPM "quote" may report all PCRs in Evidence while a Reference Value could describe a subset of PCRs.
 
 ##### Handling of new tags
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1871,7 +1871,7 @@ Otherwise, `cryptokeys` does not match.
 For each Integrity Register entry in the Reference Value, the Verifier will use the associated identifier (i.e., `integrity-register-id-type-choice`), to look up the matching Integrity Register entry in Evidence.
 If no entry is found, the Reference Value does not match.
 Instead, if an entry is found, the digest comparison proceeds as defined in {{sec-cmp-digests}} after the cross product equivalence has been found according to {{sec-comid-integrity-registers}}.
-Note that it is not required for all the entries in Evidence to be used during matching: the Reference Value could consist of a subset of the device's register space. In TPM parlance, a TPM "quote" may report all PCRs in Evidence while a Reference Value could describe a subset of PCRs.
+Note that it is not required for all the entries in Evidence to be used during matching: the Reference Value could consist of a subset of the device's register space. In TPM parlance, a TPM "quote" may report all PCRs in Evidence, while a Reference Value could describe a subset of PCRs.
 
 ##### Handling of new tags
 


### PR DESCRIPTION
Fixed erroneous wording related to TPMs and added clarity that cross-product equivalence should be applied before applying the `digests` comparison algorithm. Added reference to the cddl that defines what an "identifier" is.