### PR TITLE
Assign tag for digests

### DIFF
--- a/cddl/digest.cddl
+++ b/cddl/digest.cddl
@@ -2,3 +2,7 @@ digest = [
   alg: (int / text),
   val: bytes
 ]
+
+digests = [ + digest ]
+tagged-digests = #6.562(digests)
+digests-type-choice = digests / tagged-digests

--- a/cddl/measurement-values-map.cddl
+++ b/cddl/measurement-values-map.cddl
@@ -1,7 +1,7 @@
 measurement-values-map = non-empty<{
   ? &(version: 0) => version-map
   ? &(svn: 1) => svn-type-choice
-  ? &(digests: 2) => [ + digest ]
+  ? &(digests: 2) => digests-type-choice
   ? &(flags: 3) => flags-map
   ? (
       &(raw-value: 4) => $raw-value-type-choice,

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -299,6 +299,8 @@ should only be used when the `digest` type conveys reference value
 measurements that are matched verbatim with Evidence that uses the same
 convention - e.g., {{Section 4.4.1.5 of -psa-token}}).
 
+The `digests-type-choice` measurement is either an untagged array of `digest` or the same array tagged with the CBOR tag `#6.562`.
+
 ~~~ cddl
 {::include cddl/digest.cddl}
 ~~~
@@ -1813,9 +1815,7 @@ Reference Value does not match.
 
 ##### Comparison for digests entries {#sec-cmp-digests}
 
-The value stored under `measurement-values-map` key 2,
-or a value tagged with
-#6.TBD is a digest entry.
+The value stored under `measurement-values-map` key 2, or a value tagged with #6.562 is a digest entry.
 It contains one or more digests, each measuring the
 same object. A Reference Value may contain multiple digests, each with a
 different algorithm acceptable to the Reference Value provider. If the
@@ -2023,7 +2023,8 @@ IANA is requested to allocate the following tags in the "CBOR Tags" registry {{!
 |     559 | `digest`            | tagged-cert-thumbprint-type, see {{sec-crypto-keys}}                 | {{&SELF}} |
 |     560 | `bytes`             | tagged-bytes, see {{sec-common-tagged-bytes}}                        | {{&SELF}} |
 |     561 | `digest`            | tagged-cert-path-thumbprint-type, see  {{sec-crypto-keys}}           | {{&SELF}} |
-| 562-599 | `any`               | Earmarked for CoRIM                                                  | {{&SELF}} |
+|     562 | `[ + digest ]`      | tagged-digests, see {{sec-common-hash-entry}}                        | {{&SELF}} |
+| 563-599 | `any`               | Earmarked for CoRIM                                                  | {{&SELF}} |
 
 Tags designated as "Earmarked for CoRIM" can be reassigned by IANA based on advice from the designated expert for the CBOR Tags registry.
 


### PR DESCRIPTION
Issue #154 notes that there is no tag assigned for a digests measurement when it appears at a local codepoint (for example at measurement-values-map codepoint -42).

This diff allocates the next available codepoint to inform the verifier that it should use the digests type.