### PR TITLE
Remove bad line break and add comma

### DIFF
--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -430,8 +430,7 @@ The following describes each child element of this type.
 
 Profiling is the mechanism that allows the base CoRIM schema to be customised to fit a specific Attester.
 
-A profile defines which of the optional parts of a CoRIM are required,
-which are prohibited and which extension points are exercised and how.
+A profile defines which of the optional parts of a CoRIM are required, which are prohibited, and which extension points are exercised and how.
 A profile MUST NOT alter the syntax or semantics of a standard CoRIM type.
 A profile MAY constrain the values of a given CoRIM type to a subset of the values.
 A profile MAY extend the set of a given CoRIM type using the defined extension points (see {{sec-extensibility}}).


### PR DESCRIPTION
The draft guidelines say to keep sentences on an unbroken line. A list of three or more objects should have commas after each element for clearer parsability (Oxford comma).