### PR TITLE
Clarify "standard CoRIM type"

### DIFF
--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -453,7 +453,6 @@ that MUST have a different identifier.
 {::include cddl/profile-type-choice.cddl}
 ~~~
 
-A "standard CoRIM type" references definitions in {{sec-corim-cddl}} and any further definitions in relevant IANA registries.
 
 ### Entities {#sec-corim-entity}
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -453,6 +453,8 @@ that MUST have a different identifier.
 {::include cddl/profile-type-choice.cddl}
 ~~~
 
+A "standard CoRIM type" references definitions in {{sec-corim-cddl}} and any further definitions in relevant IANA registries.
+
 ### Entities {#sec-corim-entity}
 
 The CoRIM Entity is an instantiation of the Entity generic
@@ -1352,7 +1354,8 @@ CDDL map extension points have the form `($$NAME-extension)` where "NAME" is the
 and '$$' signifies map extensibility. Typically, map extension requires a convention
 for code point naming that avoids code-point reuse.
 Well-known code points may be in a registry, such as CoSWID {{-coswid-reg}}.
-Additionally, a range of code points may be reserved for vendor-specific use such as negative integers.
+Any negative integer may be assigned meaning locally to the profile extending the map type.
+Non-negative integers are reserved for IANA to assign meaning globally.
 
 ### Data Type Extensions
 
@@ -2183,7 +2186,7 @@ Environments (CoRE) Parameters" Registry {{!IANA.core-parameters}}:
 
 --- back
 
-# Full CoRIM CDDL
+# Full CoRIM CDDL {#sec-corim-cddl}
 
 ~~~ cddl
 {::include cddl/corim-autogen.cddl}

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -432,7 +432,7 @@ Profiling is the mechanism that allows the base CoRIM schema to be customised to
 
 A profile defines which of the optional parts of a CoRIM are required,
 which are prohibited and which extension points are exercised and how.
-A profile MUST NOT alter the syntax or semantics of a standard CoRIM type.
+A profile MUST NOT alter the syntax or semantics of CoRIM types defined in this document.
 A profile MAY constrain the values of a given CoRIM type to a subset of the values.
 A profile MAY extend the set of a given CoRIM type using the defined extension points (see {{sec-extensibility}}).
 Exercised extension points should preserve the intent of the original semantics.

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1353,7 +1353,6 @@ CDDL map extension points have the form `($$NAME-extension)` where "NAME" is the
 and '$$' signifies map extensibility. Typically, map extension requires a convention
 for code point naming that avoids code-point reuse.
 Well-known code points may be in a registry, such as CoSWID {{-coswid-reg}}.
-Any negative integer may be assigned meaning locally to the profile extending the map type.
 Non-negative integers are reserved for IANA to assign meaning globally.
 
 ### Data Type Extensions


### PR DESCRIPTION
There's a base schema and there's a standard type, so we ought to define the separate concepts.