### PR TITLE
Remove validity-map from core and remove meta-map

### DIFF
--- a/asides/theory-of-validity.md
+++ b/asides/theory-of-validity.md
@@ -1,0 +1,129 @@
+# CoRIM Validity Operational Model
+
+The claims in a CoRIM document all have different interpretations and impact on security posture.
+This document describes how component vendors and environment compositors may structure their issuance of CoRIMs to assign appropriate lifetimes to different sorts of claims.
+The main position is that the validity of claims should be bound to the validity of their signatures.
+Public key infrastructure (PKI) already provides mechanisms for certificate lifetimes and otherwise revocation of certificates.
+The CoRIM specification does not seek to reinvent the notion of validity of the CoRIM itself.
+
+## Fundamentals
+
+The typical chain of trust for keys has three levels: a root certificate authority, an intermediate certificate authority, and a signing key.
+Every cryptographic signing algorithm has a limit of how many messages a key may sign before weakening the private key's secrecy.
+To avoid exhausting a signer's source of trust, the signer will generate new keys and sign those keys' certificates with a trusted key.
+If keys are generated frequently enough, that certificate signing key will also need to periodically get refreshed.
+To refresh the intermediate key, you may have yet another intermediate key recursively, or a root key to provide the intermediate certificate authority's certificate.
+
+A key may have its certificate reissued if it is near expiration, without needing new key material.
+To ensure continuity, that key may have an identifier separate from the certificate itself.
+A signed message may then bind its content to the key by including the key's identifier in its protected headers, for example.
+
+## Certificate lifetime and OCSP
+
+Certificates are invalid if they have expired or have been revoked.
+Certificate revocation through certificate revocation lists is a generally unscalable solution for a large amount of certificates.
+The Online Certificate Status Protocol makes it quick to check the status of a certificate's validity, but also leaves no time to respond to an incident to update environments and ensure continuity of service.
+Revocation should be considered an emergency lockout due to key compromise only.
+
+If the contents of a message should not be considered trustworthy for a long period of time, its signing key's certificate should have a short expiry period.
+If the contents of the message are still considered trustworthy after the expiration period, the issuer of the message may reissue a certificate for its signing key.
+
+### Certificate lifetime example: TLS
+
+As of 2023, a typical expiration duration (lifetime) for a TLS key certificate is 398 days.
+Due to the prevalence of outages for expired certificates, it's advisable to set the lifetime closer to 90 days to ensure you have the necessary online infrastructure to maintain certificate freshness.
+Some managed certificate authority services have a default lifetime of 7 days given the target enterprise users are expected to have tighter security requirements.
+
+## Authenticity
+
+Claims of authenticity are fundamentally different from claims of security.
+If a firmware vendor produces a binary and signs its measurement, that measurement is bound to the vendor.
+The claim of security version number for that firmware is also immutable, as it can only increase across versions with new binaries.
+
+Claims of authenticity can be longer term claims to not require online infrastructure to re-certify periodically.
+This model is similar to distributing package signatures with packages.
+Authenticity claims are not required to be long-term, but in heterogeneous environments, maintaining freshness of a large multitude of packages frequently can be an undesirable operational model.
+
+## Confidence
+
+The knowledge that we have about security properties of measured artifacts can change over time.
+For stronger attestation appraisal policies, operators and supply chain providers may provide notes about vulnerabilities of specific releases.
+A claim that an artifact has no known vulnerabilities should have a short lifetime to ensure that knowledge stays relatively fresh.
+
+The RIM issuer for such claims may then choose to operate a service to provide RIMs signed by keys with short term certificates.
+Signatures do not need to be generated on-demand; a background job not connected to the external network may have access to signing key material to keep signatures fresh.
+
+For irrevocable claims, the claims may come with a proof of inclusion in a trusted append-only log.
+
+### Confidence Example: Security Version Number
+
+The AMD SEV-SNP versioned chip endorsement key (VCEK) signs its attestation reports.
+Key is versioned to the host firmware components by combining their version numbers with a unique device secret in a key derivation function.
+The key's certificate is bound to the host firmware version numbers via an X.509 certificate extension.
+When there as a vulnerability in a host firmware component, new components are released with new security version numbers, and partners are informed of the new release.
+The old VCEK certificate is still authentically signed by AMD, and will not be revoked.
+It's up to platform providers to update host components within a reasonable timeframe.
+It's up to attestation verification policy whether to permit any connections in the interval between manufacturer security version number increase and the platform provider's ability to enforce that minimum version of firmware across its fleet.
+
+The platform provider is incentivized to publish its own CoRIM family for fleetwide guarantees for minimum host firmware versions to give customers confidence to update attestation policy without fear of induced outages from attestation failure.
+
+### Confidence Example: Software Component Analysis
+
+Composite environments should undergo routine component analyses to match recent supply chain information with the environment's components.
+The Grafeas project provides a model for matching supply chain notes of vulnerable dependencies with instances of analyses for the current state of a composite environment (e.g., a container).
+An online CoRIM service may provide access to the latest certificates of recent analysis results for artifacts they offer composite CoRIMs for.
+The service is a front end for read-only access to stored results generated offline.
+
+## Service model
+
+With short-term claims come long-term service maintenance responsibilities.
+In order to keep certificates fresh, you need to have regular processes for provisioning new certificates.
+In order for those certificates to make it to users, you need an online service users connect to.
+For best key management purposes, it's best to make these processes separate such that certificate provisioning happens on devices without direct access to the external network.
+
+Not every claim provider (e.g., product team) needs to run a service if they are authorized to submit claims to a more centralized repository of knowledge (e.g., organization).
+
+### Frontend service: Query CoRIM
+
+The Veraison project supports a RESTful API to ingest supply chain information to its in-memory body of knowledge.
+The in-memory body of knowledge is "matched" against to determine which claims by whom apply to a stateful environment.
+Consider turning the matching logic into a query-API for any verification engine to use for their body of knowledge.
+
+#### Example interaction:
+
+> Query: Which CoRIMs match PCR0=ABCD, PCR7=1234?
+> Response: CoRIMs H,I, and J all describe that PCR set.
+>  Upon further inspection, CoRIM H includes an endorsement that the PCR0 value is the latest from the manufacturer (lifetime 5 more days).
+>  CoRIM I authorizes PCR0 as an authentic firmware for the manufacturer (lifetime 5 years)
+>  CoRIM J authorizes the combination of PCR0 and PCR7 as a company Y value-added composition.
+
+It's only CoRIM J that permits the PCR set as a slice, but the additions of endorsements from further down the supply chain add to the stateful environment that the verifier is building about the attesting environment.
+
+### Backend service: CoRIM repository
+
+Whereas the query-based frontend is useful for small queries meant to run during an online attestation flow, organizations that provide a large amount of artifacts to many users through intermediaries will want their repository of knowledge to follow their artifacts.
+The organization that publishes information about their artifacts does so through a set of publish/subscribe topics that they work with intermediaries to subscribe to.
+Some topics may be open for anyone to subscribe to, or some combination of allow/deny lists.
+This content delivery model is called federation.
+The pub/sub pathways provide batch delivery modes to propagate knowledge amongst participants in this federation of knowledge bases.
+
+The expectation for such servers is to provide reference values and endorsements upon or prior to availability of a new release of a particular class of attesting environment.
+News of releases ahead of availability allows users to audit changes or update attestation policies in response.
+
+#### Example interaction:
+
+An OS distributor creates a new release of their Product-X.Y family of releases, Product-X.Y-20240422 to mitigate a vulnerability, and its CoRIM comes with a security version number increase from 0 to 1.
+The Product-X.Y topic is updated to the new release's CoRIM, but Product-X.Y-20230801 still has the old CoRIM.
+The Product-X.Y-svn topic is updated to the new security version number.
+The Product-X.Y-svn-0 topic is updated with the associated CVE+CVSSs.
+
+Note: topics can be established with appropriate authorization policies to only propagate information to parties included in a vulnerability embargo.
+
+A Cloud Provider subscribing to this family of products ingests the new image and latest security version number.
+A background process updates internal knowledge representation.
+The Cloud Provider's Attestation Verification Service stops issuing EATs with the "latest" and "svn-latest" claims for machines running the old release.
+Projects using Product-X.Y get a security notice that their workloads are not attesting with svn-latest, but instead have a claim with associated vulnerabilities listed.
+
+Note: the vulnerabilities list could be delivered through a different channel from the verifier service to a dashboard due to the sensitivity.
+
+The project has an auto-upgrade workflow to begin a migration process to shed workloads to new instances it assembles from the latest release.

--- a/cddl/concise-bom-tag.cddl
+++ b/cddl/concise-bom-tag.cddl
@@ -1,6 +1,5 @@
 concise-bom-tag = {
   &(tag-identity: 0) => tag-identity-map
   &(tags-list: 1) => [ + tag-identity-map ],
-  &(bom-validity: 2) => validity-map
   * $$concise-bom-tag-extension
 }

--- a/cddl/corim-frags.mk
+++ b/cddl/corim-frags.mk
@@ -73,7 +73,6 @@ CORIM_FRAGS += tagged-concise-swid-tag.cddl
 CORIM_FRAGS += tagged-concise-mid-tag.cddl
 CORIM_FRAGS += tagged-concise-bom-tag.cddl
 CORIM_FRAGS += unprotected-corim-header-map.cddl
-CORIM_FRAGS += validity-map.cddl
 
 CORIM_FRAGS += $(COMID_FRAGS)
 

--- a/cddl/corim-map.cddl
+++ b/cddl/corim-map.cddl
@@ -3,7 +3,6 @@ corim-map = {
   &(tags: 1) => [ + $concise-tag-type-choice ]
   ? &(dependent-rims: 2) => [ + corim-locator-map ]
   ? &(profile: 3) => $profile-type-choice
-  ? &(rim-validity: 4) => validity-map
   ? &(entities: 5) => [ + corim-entity-map ]
   * $$corim-map-extension
 }

--- a/cddl/corim-meta-map.cddl
+++ b/cddl/corim-meta-map.cddl
@@ -1,4 +1,0 @@
-corim-meta-map = {
-  &(signer: 0) => corim-signer-map
-  ? &(signature-validity: 1) => validity-map
-}

--- a/cddl/protected-corim-header-map.cddl
+++ b/cddl/protected-corim-header-map.cddl
@@ -2,6 +2,6 @@ protected-corim-header-map = {
   &(alg: 1) => int
   &(content-type: 3) => "application/corim-unsigned+cbor"
   &(kid: 4) => bstr
-  &(corim-meta: 8) => bstr .cbor corim-meta-map
+  &(corim-signer-map: 9) => bstr .cbor corim-signer-map
   * cose-label => cose-value
 }

--- a/cddl/validity-map.cddl
+++ b/cddl/validity-map.cddl
@@ -1,4 +1,0 @@
-validity-map = {
-  ? &(not-before: 0) => time
-  &(not-after: 1) => time
-}

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -230,25 +230,6 @@ The following describes each member of the `entity-map`.
 Examples of how the `entity-map` generic is instantiated can be found in
 {{sec-corim-entity}} and {{sec-comid-entity}}.
 
-### Validity {#sec-common-validity}
-
-A `validity-map` represents the time interval during which the signer
-warrants that it will maintain information about the status of the signed
-object (e.g., a manifest).
-
-In a `validity-map`, both ends of the interval are encoded as epoch-based
-date/time as per {{Section 3.4.2 of -cbor}}.
-
-~~~ cddl
-{::include cddl/validity-map.cddl}
-~~~
-
-* `not-before` (index 0): the date on which the signed manifest validity period
-  begins
-
-* `not-after` (index 1): the date on which the signed manifest validity period
-  ends
-
 ### UUID {#sec-common-uuid}
 
 Used to tag a byte string as a binary UUID defined in {{Section 4.1.2. of
@@ -340,8 +321,6 @@ A profile allows the base CoRIM CDDL definition to be customized to fit a specif
 A profile MUST NOT change the base CoRIM CDDL definition's semantics, which includes not changing or overloading names and numbers registered at IANA registries used by this document.
 For more detail, see {{sec-corim-profile-types}},
 
-* A validity period, which indicates the time period for which the CoRIM contents are valid.
-
 * Information about the supply chain entities responsible for the contents of the CoRIM and their associated roles.
 
 A CoRIM can be signed ({{sec-corim-signed}}) using COSE Sign1 to provide end-to-end security to the CoRIM contents.
@@ -381,10 +360,7 @@ The following describes each child item of this map.
   entire CoRIM.  If missing, the profile defaults to DICE.
   Described in {{sec-corim-profile-types}}
 
-* `rim-validity` (index 4): Specifies the validity period of the CoRIM.
-  Described in {{sec-common-validity}}
-
-* `entities` (index 5): A list of entities involved in a CoRIM life-cycle.
+* `entities` (index 4): A list of entities involved in a CoRIM life-cycle.
   Described in {{sec-corim-entity}}
 
 * `$$corim-map-extension`: This CDDL socket is used to add new information
@@ -486,7 +462,7 @@ The CoRIM MUST be signed by the CoRIM creator.
 
 The following CDDL specification defines a restrictive subset of COSE header
 parameters that MUST be used in the protected header alongside additional
-information about the CoRIM encoded in a `corim-meta-map` ({{sec-corim-meta}}).
+information about the CoRIM encoded in a `corim-signer-map` ({{sec-corim-signer}}).
 
 ~~~ cddl
 {::include cddl/cose-sign1-corim.cddl}
@@ -524,24 +500,10 @@ The following describes each child item of this map.
 
 Additional data can be included in the COSE header map as per {{Section 3 of -cose}}.
 
-### Meta Map {#sec-corim-meta}
-
-The CoRIM meta map identifies the entity or entities that create and sign the CoRIM.
-This ensures the consumer is able to identify credentials used to authenticate its signer.
-
-~~~ cddl
-{::include cddl/corim-meta-map.cddl}
-~~~
-
-The following describes each child item of this group.
-
-* `signer` (index 0): Information about the entity that signs the CoRIM.
-  Described in {{sec-corim-signer}}
-
-* `signature-validity` (index 1): Validity period for the CoRIM. Described in
-  {{sec-common-validity}}
-
 #### Signer Map {#sec-corim-signer}
+
+The CoRIM signer map identifies the entity or entities that create and sign the CoRIM.
+This ensures the consumer is able to identify credentials used to authenticate its signer.
 
 ~~~ cddl
 {::include cddl/corim-signer-map.cddl}
@@ -1409,9 +1371,6 @@ The following describes each member of the `concise-bom-tag` map.
   appraisal process. The activation is atomic: all tags listed in `tags-list`
   MUST be activated or no tags are activated.
 
-* `bom-validity` (index 2): Specifies the validity period of the CoBOM.
-  Described in {{sec-common-validity}}
-
 * `$$concise-bom-tag-extension`: This CDDL socket is used to add new
   information structures to the `concise-bom-tag`.  See {{sec-iana-cobom}}.
   The `$$concise-bom-tag-extension` extension socket is empty in this
@@ -1476,7 +1435,7 @@ The primary goal of this phase is to ensure that all necessary information is av
 
 All available CoRIMs are collected.
 
-CoRIMs that are not within their validity period, or that cannot be associated with an authenticated and authorised source MUST be discarded.
+CoRIMs that cannot be associated with an authenticated and authorised source, including the time-based validity of the signing key certificate, MUST be discarded.
 
 Any CoRIM that has been secured by a cryptographic mechanism, such as a signature, that fails validation MUST be discarded.
 
@@ -1492,8 +1451,6 @@ Later stages will further select the CoRIMs appropriate to the Evidence Appraisa
 This section is not applicable if the Verifier appraisal policy does not require CoBOMs.
 
 All the available Concise Bill Of Material (CoBOMs) tags are collected from the selected CoRIMs.
-
-CoBOMs which are not within their validity period, or reference tags that are not available to the verifier, are discarded.
 
 The Verifier processes all CoBOMs that are valid at the point in time of Evidence Appraisal and activates all tags referenced therein.
 


### PR DESCRIPTION
The validity of a document should be determined by the signing key's expiration. Any other form of validity should be an extension to the base.

Since the meta-map only had the signer-map in it, I've collapsed that indirection. If the overall corim validity-map is still desired, we can add that as a standard extension as per issue #223

Closes Issue #222