### PR TITLE
Disambiguate endorsed-triples semantics.

### DIFF
--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1107,11 +1107,7 @@ Environment.
 
 #### Endorsed Values Triple {#sec-comid-triple-endval}
 
-An Endorsed Values triple declares additional measurements that are valid when
-a Target Environment has been verified against reference measurements. For
-Endorsed Value Claims, the subject is either a Target or Attesting Environment,
-the object contains measurements, and the predicate defines semantics for how
-the object relates to the subject.
+An Endorsed Values triple declares additional measurements to add to the ACS.
 
 ~~~ cddl
 {::include cddl/endorsed-triple-record.cddl}


### PR DESCRIPTION
Addresses Issue #251. It's unclear if this implicit condition is also expected of the conditional-endorsement-series-triples and conditional-endorsement-triples. The phasing in the appraisal section seems to suggest that it should be. That would seem to mean that if you want "unconditional" endorsements, you need to have a reference-triple-record that has an empty measurement-values-map, but that is ill-formed.

Probably the location is wrong and this should be a subsection of `Endorsed Values Augmentation (Phase 4)`, but I want to at least clarify if this is the intended meaning. The "Interacting with an ACS" section suggests that an endorsement always has a list of conditions, but that isn't material in the representation of an endorsed-triple-record.