### PR TITLE
Proposal to add multiplicity of Measurement Maps

### DIFF
--- a/cddl/corim-frags.mk
+++ b/cddl/corim-frags.mk
@@ -47,6 +47,7 @@ COMID_FRAGS += version-map.cddl
 COMID_FRAGS += digest.cddl
 COMID_FRAGS += integrity-registers.cddl
 COMID_FRAGS += concise-swid-tag.cddl
+COMID_FRAGS += measurement-maps-type-choice.cddl
 
 COMID_EXAMPLES := $(wildcard examples/comid-*.diag)
 

--- a/cddl/endorsed-triple-record.cddl
+++ b/cddl/endorsed-triple-record.cddl
@@ -1,4 +1,4 @@
 endorsed-triple-record = [
   environment-map
-  measurement-map
+  measurement-maps-type-choice
 ]

--- a/cddl/measurement-maps-type-choice.cddl
+++ b/cddl/measurement-maps-type-choice.cddl
@@ -1,0 +1,1 @@
+measurement-maps-type-choice = measurement-map / #6.533([ measurement-map ])

--- a/cddl/reference-triple-record.cddl
+++ b/cddl/reference-triple-record.cddl
@@ -1,4 +1,4 @@
 reference-triple-record = [
   environment-map
-  measurement-map
+  measurement-maps-type-choice
 ]

--- a/cddl/stateful-environment-record.cddl
+++ b/cddl/stateful-environment-record.cddl
@@ -1,5 +1,5 @@
 ; an environment with a set of measurements that must match evidence
 stateful-environment-record = [
   environment-map,
-  measurement-map
+  measurement-maps-type-choice
 ]

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1202,8 +1202,8 @@ measurements for the Target Environment.
 #### Conditional Endorsement Series Triple {#sec-comid-triple-cond-series}
 
 A Conditional Endorsement Series triple uses a stateful environment, (i.e., `stateful-environment-record`),
-that identifies a Target Environment based on an `environment-map` plus the `measurement-map` measurements
-that have matching Evidence.
+that identifies a Target Environment based on an `environment-map` plus either measurements for a single measured element
+via `measurement-map` or multiple measured elements using `[measurement-map]`that have matching Evidence.
 
 The stateful Target Environment is a triple subject that MUST be satisfied before the series triple object is
 matched.


### PR DESCRIPTION
Modern day attesters have Multiple Measured Elements, within a Target Environment. This PR intends to allow multiple measured elements to be expressed using a single Reference Value Triple.