### PR TITLE
Account for multiplicity in conditional endorsements

### DIFF
--- a/cddl/conditional-series-record.cddl
+++ b/cddl/conditional-series-record.cddl
@@ -1,6 +1,6 @@
 conditional-series-record = [
-  ; reference values to be matched against evidence
-  refv: measurement-values-map
+  ; reference values to be matched against evidence in each mkey
+  refv: [ + measurement-map ]
   ; endorsed values that apply in case revf matches
-  endv: measurement-values-map
+  endv: [ + mkeyvalue-pair ]
 ]

--- a/cddl/corim-frags.mk
+++ b/cddl/corim-frags.mk
@@ -47,7 +47,6 @@ COMID_FRAGS += version-map.cddl
 COMID_FRAGS += digest.cddl
 COMID_FRAGS += integrity-registers.cddl
 COMID_FRAGS += concise-swid-tag.cddl
-COMID_FRAGS += measurement-maps-type-choice.cddl
 
 COMID_EXAMPLES := $(wildcard examples/comid-*.diag)
 

--- a/cddl/endorsed-triple-record.cddl
+++ b/cddl/endorsed-triple-record.cddl
@@ -1,4 +1,4 @@
 endorsed-triple-record = [
   environment-map
-  measurement-maps-type-choice
+  [ + measurement-map ]
 ]

--- a/cddl/measurement-maps-type-choice.cddl
+++ b/cddl/measurement-maps-type-choice.cddl
@@ -1,1 +1,1 @@
-measurement-maps-type-choice = measurement-map / #6.533([ measurement-map ])
+measurement-maps-type-choice = measurement-map / [ + measurement-map ]

--- a/cddl/reference-triple-record.cddl
+++ b/cddl/reference-triple-record.cddl
@@ -1,4 +1,4 @@
 reference-triple-record = [
   environment-map
-  measurement-maps-type-choice
+  [ + measurement-map ]
 ]

--- a/cddl/stateful-environment-record.cddl
+++ b/cddl/stateful-environment-record.cddl
@@ -1,5 +1,5 @@
 ; an environment with a set of measurements that must match evidence
 stateful-environment-record = [
   environment-map,
-  measurement-maps-type-choice
+  [ + measurement-map ]
 ]


### PR DESCRIPTION
A conditional endorsement series is about a target environment plus additional state expectations that lead to further endorsements.

I removed the undefined CBOR tag around multiple measuremnt-maps since array and map have different CBOR major tags and a custom tag is not required.