### PR TITLE
Rework ECT comparison section to match new internal representation

### DIFF
--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1932,7 +1932,7 @@ Reference Value Providers (RVP) publish Reference Values triples that are matche
 Reference Values may describe multiple acceptable states for Attesters; hence "matching" determines that Evidence (contained in the ACS) satisfies an appropriate subset of the available Reference Values.
 If the appropriate subset matches, the authority of the RVP is added to the appropriate ACS entries.
 
-The Verifier compares each `reference-triple-record` against ACS entries as described in {{sec-match-one-se}}, where the `reference-triple-record` takes the place of a `stateful-environment-record`.
+The Verifier compares each `reference-triple-record` against ACS entries as described in {{sec-match-condition-ect}}, where the `reference-triple-record` takes the place of a `stateful-environment-record`.
 If all fields of the `reference-triple-record` match the ACS, then the Verifier MUST add the RVP authority to each matching ACS field.
 
 If any `reference-triple-record` in the Reference Value triple does not match the ACS then the entire triple is ignored.
@@ -1952,7 +1952,7 @@ The verifier checks whether Conditional Endorsements are applicable by comparing
 
 #### Processing Conditional Endorsement Triple
 
-For each Conditional Endorsement Triple the Verifier compares each of the `stateful-environment-record` fields from the `cond` field in the triple against the ACS (see {{sec-match-one-se}}).
+For each Conditional Endorsement Triple the Verifier compares each of the `stateful-environment-record` fields from the `cond` field in the triple against the ACS (see {{sec-match-condition-ect}}).
 
 If every stateful environment matches a corresponding ACS entry, then the Verifier MUST add an Endorsement entry to the ACS (see {{sec-add-to-acs}}) for each `endorsed-triple-record` in the `endorsements` field.
 Each Endorsement from the `endorsed-triple-record` includes the authority which signed the Conditional Endorsement Triple.
@@ -1961,36 +1961,10 @@ Each Endorsement from the `endorsed-triple-record` includes the authority which 
 
 For each Conditional Endorsement Series Triple the Verifier iterates over the `conditional-series-record`s within the triple, stopping if it finds a match.
 
-For each iteration, the Verifier creates a temporary `stateful-environment-record` by merging the `stateful-environment-record` in the triple with the `refv` field in the `conditional-series-record`. It compares this temporary record against the ACS (see {{sec-match-one-se}}).
+For each iteration, the Verifier creates a temporary `stateful-environment-record` by merging the `stateful-environment-record` in the triple with the `refv` field in the `conditional-series-record`. It compares this temporary record against the ACS (see {{sec-match-condition-ect}}).
 
 If one of the temporary records matches then the Verifier MUST add the `endv` Endorsement entry to the ACS.
 This Endorsement includes the authority which signed the Conditional Endorsement Series Triple.
-
-#### Processing a stateful environment against the Appraisal Claims Set {#sec-match-one-se}
-
-This section describes how a stateful environment is matched against an ACS entry.
-If any part of the processing indicates that the stateful environment does not match then the remaining steps in this section are skipped for that stateful environment.
-
-The Verifier initializes a temporary "candidate entries" variable with all entries in the ACS where the stateful enviromnment `environment-map` is a subset of the ACS `environment-map`.
-
-A stateful environment `environment-map` is a subset of an ACS entry `environment-map` if each field (for example `class`, `instance` etc.) which is present in the stateful environment `environment-map` is also present in the ACS entry, and the CBOR encoded field values in the stateful environment and ACS entry are binary identical.
-If a field is not present in the stateful environment `environment-map` then the presence of, and value of, the corresponding ACS entry field does not affect whether the `environment-map`s are subsets.
-
-Before performing the binary comparison, a Verifier SHOULD convert `environment-map` fields into a form which meets CBOR Core Deterministic Encoding Requirements {{-cbor}}.
-
-If the stateful environment contains an `authorized-by` field then the Verifier SHALL remove all candidate entries whose `authorized-by` field does not contain one of the keys listed in the stateful environment `authorized-by` field (see {{sec-authorized-by}} for more details).
-
-If there are no candidate entries then the triple containing the stateful environment does not match.
-
-The stateful environment entry is compared against each of the candidate entries.
-
-For each of the candidate entries, the Verifier SHALL iterate over the codepoints which are present in the `measurement-values-map` field within the stateful environment `measurement-map`.
-Each of the codepoints present in the stateful environment is compared against the candidate entry.
-
-If any codepoint present in the stateful environment `measurement-values-map` does not match the same codepoint within the candidate entry `measurement-values-map` then the stateful environment does not match.
-
-If all checks above have been performed successfully then the stateful environment matches.
-If none of the candidate entries match the stateful environment entry then the stateful environment does not match.
 
 ## Examples for optional phases 5, 6, and 7 {#sec-phases567}
 
@@ -2089,31 +2063,66 @@ Logically, new ECT entries are appended to the existing ACS.
 But implementations may optimize ECT order to achieve better performance.
 Additions to the ACS MUST be atomic.
 
-## ECT Comparison {#sec-ect-compare}
+## Comparing a condition ECT against the ACS {#sec-match-condition-ect}
 
 [^issue] https://github.com/ietf-rats-wg/draft-ietf-rats-corim/issues/71
 
-This specification defines the comparison algorithm for the codepoints described in sub-sections below.
-A CoRIM profile may define additional negative codepoints and their matching algorithms.
-Specifications that extend CoMID MUST also define comparison algorithms for their added codepoints.
-If a codepoint's comparison algorithm is not stated or does not default to the comparison algorithms described in this specification, then the Verifier MUST compare the binary equality of the CBOR encodings of the values.
+The algorithm used to compare a condition ECT against the ACS is stateless, it depends only on the condition ECT being compared and the contents of the ACS at the time of the comparison
+
+The Verifier uses a temporary "candidate entries" array as part of the comparision. Each element in the array is an ECT.
+
+After completing the steps described in this sub-section, the algorithm returns false if the candidate entries array is empty, true if it contains one or more elements.
 
 ### Environment Comparison {#sec-compare-env}
 
+The verifier SHALL iterate over all entries in the ACS and SHALL add each entry where the condition ECT stateful enviromnment `environment-map` is a subset of the ACS entry `environment-map` to the candidate entries array.
+
+The condition ECT `environment-map` is a subset of an ACS entry `environment-map` if each field (for example `class`, `instance` etc.) which is present in the condition ECT `environment-map` is also present in the ACS entry, and the CBOR encoded field values in the stateful environment and ACS entry are binary identical.
+If a field is not present in the condition ECT `environment-map` then the presence of, and value of, the corresponding ACS entry field does not affect whether the `environment-map`s are subsets.
+
+Before performing the binary comparison, a Verifier SHOULD convert `environment-map` fields into a form which meets CBOR Core Deterministic Encoding Requirements {{-cbor}}.
+
+### Mkey comparison {#sec-compare-mkey}
+
+The verifier SHALL iterate over all entries in the candidate entries array and compare the condition ECT `measurement-map/mkey` value to the candidate entry `measurement-map/mkey` value.
+If the two `mkey` values are not binary equal then the candidate entry is removed from the candidate entries array.
+
+Before performing the binary comparison, a Verifier SHOULD convert `mkey` fields into a form which meets CBOR Core Deterministic Encoding Requirements {{-cbor}}.
+
+If the `mkey` field is not present in neither the condition ECT nor the candidate entry then the `mkey` are equal and the candidate entry is not removed.
+If the `mkey` field is not present in only one side of the comparison then the `mkey` are not equal and the candiate entry is removed.
+
+### Authority comparison
+
+The verifier SHALL iterate over all entries in the candidate entries array and compare the condition ECT expected authority (`a`) value to the candidate entry authority value.
+
+If the condition ECT contains an `a` field then the Verifier SHALL remove all candidate entries whose `authorized-by` field does not contain one of the keys listed in the condition ECT `authorized-by` field (see {{sec-authorized-by}} for more details).
+
+When comparing two `$crypto-key-type-choice` fields for equality, the verifier SHALL treat then as equal if their CBOR encoding is binary equal.
+
+The verifier MAY treat two keys as equal if they have different formats but represent the same key.
+For example, the verifier may contain code to compare a key fingerprint against the key which, when hashed, creates that fingerprint.
+
 ### Claims Comparison  {#sec-compare-claims}
 
-#### Comparison of measurement-values-map {#sec-match-one-codepoint}
+The verifier SHALL iterate over all entries in the candidate entries array and compare the condition ECT claims to the candidate entry authority claims.
 
-This section describes the algorithm used to compare the `measurement-values-map` codepoints of an ECT with another ECT.
-The comparison algorithm performed depends on the value of the codepoint being compared.
+The Verifier SHALL iterate over the codepoints which are present in the `measurement-values-map` field within the condition ECT `measurement-map`.
+Each of the codepoints present in the condition ECT is compared against the same codepoint in the candidate entry.
 
-[^issue] https://github.com/ietf-rats-wg/draft-ietf-rats-corim/issues/203
+If any codepoint present in the condition ECT `measurement-values-map` does not have a corresponding codepoint within the candidate entry `measurement-values-map` then verifier SHALL remove that candidate entry from the candidate entries array.
 
-If the `measurement-values-map` value has an associated CBOR tag, the comparison algorithm should comprehend the structure identified by the CBOR tag.
+If any codepoint present in the condition ECT `measurement-values-map` does not match the same codepoint within the candidate entry `measurement-values-map` then verifier SHALL remove that candidate entry from the candidate entries array.
 
-If the Verifier does not recognize a CBOR tag value then the value MUST NOT match.
+#### Comparison of a single measurement-values-map codepoint{#sec-match-one-codepoint}
 
-Note: CBOR tags are useful for discriminating values amongst alternates, but the comparison of tagged values is still determined by the codepoint they appear under. It is recommended but not required to compare values with a specific CBOR tag the same way across codepoints. For this reason, it is recommended to specify a default comparison algorithm with the CBOR tag's registration.
+If the codepoint key is zero or positive then the Verifier SHALL use a standard comparison algorithm, defined in this document, to compare the claims.
+The codepoint number and, if present, the tag value associated with the condition ECT codepoint SHALL be used to select the algorithm.
+
+If the codepoint key is negative then the Verifier MAY use a comparison algorithm defined by the appropriate CoRIM profile to compare the claims.
+The codepoint number, the profile associated with the condition ECT, and the tag value (if present) shall be used to select the algorithm.
+
+If the verifier is unable to determine the comparison algorithm which applies to a codepoint then it SHALL behave as though the candidate entry does not match the condition ECT.
 
 Profile writers SHOULD use CBOR tags for widely applicable comparison methods to ease Verifier implementation compliance across profiles.
 
@@ -2121,80 +2130,72 @@ The following subsections define the comparison algorithms for the `measurement-
 
 ##### Comparison for svn entries
 
-The value stored under `measurement-values-map` key 1 is an SVN, which must
-have type UINT.
+The value stored under `measurement-values-map` key 1 is an SVN, which must have type UINT.
 
-If the Reference value for `measurement-values-map` key 1 is an untagged UINT or
-a UINT tagged with #6.552 then an equality comparison is performed. If the value
-of the SVN in ACS is not equal to the value in the Reference
-Value then the Reference Value does not match.
+If the condition ECT value for `measurement-values-map` key 1 is an untagged UINT or a UINT tagged with #6.552 then an equality comparison is performed.
+The comparison MUST return true if the value of the SVN in the candidate entry is equal to the value in the condition ECT.
 
-If the Reference value for `measurement-values-map` key 1 is a UINT tagged with
-#6.553 then a minimum comparison is performed. If the value of the SVN in
-ACS less than the value in the Reference Value then the
-Reference Value does not match.
+If the condition ECT value for `measurement-values-map` key 1 is a UINT tagged with #6.553 then a minimum comparison is performed.
+The comparison MUST return true if the value of the SVN in the candidate entry is less than the value in the condition ECT.
 
 ##### Comparison for digests entries {#sec-cmp-digests}
 
-The value stored under `measurement-values-map` key 2,
-or a value tagged with
-#6.TBD is a digest entry.
-It contains one or more digests, each measuring the
-same object. A Reference Value may contain multiple digests, each with a
-different algorithm acceptable to the Reference Value provider. If the
-digest in Evidence contains a single value with an algorithm and value
-matching one of the algorithms and values in the Reference Value then it
-matches.
+The value stored under `measurement-values-map` key 2 is a digest entry.
+It contains one or more digests, each measuring the same object.
+A condition ECT may contain multiple digests, each with a different algorithm acceptable to the condition ECT author.
 
-To prevent downgrade attacks, if there are multiple algorithms which are in
-both the Evidence and Reference Value then the digests calculated using all
-shared algorithms must match.
+In the simple case, a condition ECT digests entry containing one digest matches matches a candidate entry containing a single entry with the same algorithm and value.
 
-If the CBOR encoding of the `digests` entry in the Reference Value or the
-ACS value with the same key is incorrect (for example if fields
-are missing or the wrong type) then the Reference Value does not match.
+To prevent downgrade attacks, if there are multiple algorithms which are in both the condition ECT and candidate entry then the digests calculated using all shared algorithms must match.
 
-The Verifier MUST iterate over the Reference Value `digests` array, locating
-hash algorithm identifiers that are present in the Reference Value and
-in the ACS entry.
+The comparison MUST return false if the CBOR encoding of the `digests` entry in the condition ECT or the ACS value with the same key is incorrect (for example if fields are missing or the wrong type) then the Reference Value does not match.
 
-If the hash algorithm identifier which is present in the Reference Value
-differs from the hash algorithm identifier in the ACS entry then the Reference Value does not match.
+The comparison MUST return false if the condition ECT digests entry does not contain any digests.
 
-If a hash algorithm identifier is present in both the Reference Value and
-the ACS, but the value of the hash is not binary identical
-between the Reference Value and the ACS entry then the
-Reference Value does not match.
+The comparison MUST return false if either digests entry contains multiple values for the same hash algorithm.
+
+The Verifier MUST iterate over the condition ECT `digests` array, locating common hash algorithm identifiers (which are present in the condition ECT and in the candidate entry).
+If the value associated with any common hash algorithm identifier in the condition ECT differs from the value for the same algorithm identifier in the candidate entry then the comparison MUST return false.
 
 ##### Comparison for raw-value entries
 
-> [Andy] *I think this comparison method only works if the entry is at key 4 (because
-there needs to be a mask at key 5). Should we have a Reference Value of this
-which stores `[expect-raw-value raw-value-mask]` in an array?*
+The value stored under `measurement-values-map` key 4 is a raw-value entry, which must have type BSTR.
 
-[^issue] https://github.com/ietf-rats-wg/draft-ietf-rats-corim/issues/71
+The value stored under the condition ECT `measurement-values-map` key 5 is a raw-value-mask entry, which must have type BSTR.
+
+If the condition ECT does not contain a raw-values-maek then the comparison MUST return true if the condition ECT raw-value is binary equal to the candidate entry raw-value.
+
+If the condition ECT raw-values-mask, condition ECT raw-value and candidate entry raw-value are not the same length then the comparison MUST return false.
+
+If all the lengths are the same then the verifier MUST iterate over the bits in the raw-values-mask which are 1, and compare the corresponding bits in the two raw-value fields.
+
+If, for every bit in the raw-values-mask which is 1, the corresponding bit is the same in both raw-values then the comparison MUST return true.
+
+If any masked in bit differebt between the raw values then the comparison MUST return false.
+
+Note that if a candidate entry contains a value under key 5 then this does not affect the result of the comparison.
 
 ##### Comparison for cryptokeys entries {#sec-cryptokeys-matching}
 
 The value stored under `measurement-values-map` key 12 is an array of `$crypto-key-type-choice` entries. `$crypto-key-type-choice` entries are CBOR tagged values.
 The array contains one or more entries in sequence.
 
-The CBOR tag of the first entry of the Reference Value `cryptokeys` array is compared with
-the CBOR tag of the first entry of the ACS `cryptokeys` value.
-If the CBOR tags match, then the bytes following the CBOR tag from the Reference Value entry
-are compared with the bytes following the CBOR tag from the ACS entry.
+The CBOR tag of the first entry of the condition ECT `cryptokeys` array is compared with
+the CBOR tag of the first entry of the candidate entry `cryptokeys` value.
+If the CBOR tags match, then the bytes following the CBOR tag from the condition ECT entry
+are compared with the bytes following the CBOR tag from the candidate entry.
 If the byte strings match, and there is another array entry,
-then the next entry from the Reference Values array is likewise
+then the next entry from the condition ECTs array is likewise
 compared with the next entry of the ACS array.
-If all entries of the Reference Values array match a corresponding entry in the ACS array, then the `cryptokeys` Reference Value matches.
+If all entries of the condition ECTs array match a corresponding entry in the ACS array, then the `cryptokeys` condition ECT matches.
 Otherwise, `cryptokeys` does not match.
 
 ##### Comparison for Integrity Registers {#sec-cmp-integrity-registers}
 
-For each Integrity Register entry in the Reference Value, the Verifier will use the associated identifier (i.e., `integrity-register-id-type-choice`) to look up the matching Integrity Register entry in Evidence.
-If no entry is found, the Reference Value does not match.
+For each Integrity Register entry in the condition ECT, the Verifier will use the associated identifier (i.e., `integrity-register-id-type-choice`) to look up the matching Integrity Register entry in the candidate entry.
+If no entry is found, the condition MUST return false.
 Instead, if an entry is found, the digest comparison proceeds as defined in {{sec-cmp-digests}} after equivalence has been found according to {{sec-comid-integrity-registers}}.
-Note that it is not required for all the entries in Evidence to be used during matching: the Reference Value could consist of a subset of the device's register space. In TPM parlance, a TPM "quote" may report all PCRs in Evidence, while a Reference Value could describe a subset of PCRs.
+Note that it is not required for all the entries in the candidate entry to be used during matching: the condition ECT could consist of a subset of the device's register space. In TPM parlance, a TPM "quote" may report all PCRs in Evidence, while a condition ECT could describe a subset of PCRs.
 
 ### Authority Comparison  {#sec-compare-auth}
 
@@ -2212,7 +2213,7 @@ The `cm` field comparison tests equality of one or more bits.
 
 ### Profile-directed Comparison {#sec-compare-profile}
 
-A profile may specify handling for new CBOR tagged Reference Values.
+A profile may specify handling for new CBOR tagged condition ECTs.
 The profile must specify how to compare the CBOR tagged Reference Value against the ACS.
 
 Note that the verifier may compare Reference Values in any order, so the comparison should not be stateful.


### PR DESCRIPTION
This is the first edit to section 8.9 - it aligns the terminology with the change to ECT internal representation

It also defines the comparison rules for raw-value (codepoint 4 and 5).