### PR TITLE
Account for "activating" tags from CoBOM in theory of operation.

### DIFF
--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1466,6 +1466,10 @@ CoRIM-based data structures define an external representation of Conceptual Mess
 Appraisal processing describes both mapping transformations and Verifier reconciliation ({{sec-verifier-rec}}).
 Non-CoRIM-based data structures require mapping transformation, but these are out of scope for this document.
 
+If the Verifier requires CoBOMs, then the only CoRIM inputs are those activated by the CoBOM.
+If the Verifier does not require CoBOMs, then the CoRIM inputs consist of the knowledge base of CoRIMs available to the Verifier at the beginning of appraisal.
+The knowledge base state SHOULD have an immutable label for attestation results to have auditable provenance.
+
 If a CoRIM profile is specified, there are a few well-defined points in the procedure where Verifier behaviour depends on the profile.
 The CoRIM profile MUST provide a description of the expected Verifier behavior for each of those well-defined points.
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1466,7 +1466,7 @@ CoRIM-based data structures define an external representation of Conceptual Mess
 Appraisal processing describes both mapping transformations and Verifier reconciliation ({{sec-verifier-rec}}).
 Non-CoRIM-based data structures require mapping transformation, but these are out of scope for this document.
 
-If the Verifier requires CoBOMs, then the only CoRIM inputs are those activated by the CoBOM.
+If a Verifier requires CoBOMs, then the CoRIM inputs indicated explicitly by the CoBOM are the only appropriate and required CoRIMs.
 If the Verifier does not require CoBOMs, then the CoRIM inputs consist of the knowledge base of CoRIMs available to the Verifier at the beginning of appraisal.
 The knowledge base state SHOULD have an immutable label for attestation results to have auditable provenance.
 


### PR DESCRIPTION
The CoBOM tag can help narrow a search space and make an attestation result self-explanatory, such as "unsupported CoBOM" or "missing tags x,y,z from CoBOM".
Without a CoBOM, we wanted to still ensure that the appraisal process was repeatable. Add a SHOULD for tracking the head state of the knowledge base of all input CoRIMs to an appraisal session.