### PR TITLE
ECT table readability improvements - Fixes issue #287

### DIFF
--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1694,14 +1694,14 @@ If any of the `ars-additions` are not found in the ACS then these ACS entries ar
 | ECT type      | ECT Field       | Requirement |
 |---
 | acs-condition | `environment`   | Optional    |
-|               | `elements`      | Optional    |
+|               | `element-list`  | Optional    |
 |               | `authority`     | Optional    |
-|               | `cm type`  | n/a         |
+|               | `cmtype`        | n/a         |
 |               | `profile`       | n/a         |
 | ars-addition  | `environment`   | Mandatory   |
-|               | `elements`      | Mandatory   |
+|               | `element-list`  | Mandatory   |
 |               | `authority`     | Mandatory   |
-|               | `cm type`       | Mandatory   |
+|               | `cmtype`        | Mandatory   |
 |               | `profile`       | Optional    |
 {: #tbl-ar-ect-optionality title="Attestation Results tuple requirements"}
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1647,7 +1647,7 @@ If the `selection` criteria is not satisfied, then evaluation procedes to the ne
 |           | `cm type`       | n/a         |
 |           | `profile`       | n/a         |
 | selection | `environment`   | Optional    |
-|           | `elements`      | Mandatory   |
+|           | `element-list`  | Mandatory   |
 |           | `authority`     | n/a         |
 |           | `cmtype`        | n/a         |
 |           | `profile`       | n/a         |

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1593,7 +1593,7 @@ The `addition` is added to the ACS for a specific Attester.
 | addition  | `environment`   | Mandatory   |
 |           | `element-list` | Mandatory   |
 |           | `authority`     | Mandatory   |
-|           | `cm type`       | Mandatory   |
+|           | `cmtype`        | Mandatory   |
 |           | `profile`       | Optional    |
 {: #tbl-ae-ect-optionality title="Evidence tuple requirements"}
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1670,14 +1670,14 @@ If all of the ECTs are found in the ACS then the `addition` ECTs are added to th
 | ECT type  | ECT Field       | Requirement |
 |---
 | condition | `environment`   | Optional    |
-|           | `elements`      | Optional    |
+|           | `element-list`  | Optional    |
 |           | `authority`     | Optional    |
-|           | `cm type`       | n/a         |
+|           | `cmtype`        | n/a         |
 |           | `profile`       | n/a         |
 | addition  | `environment`   | Mandatory   |
-|           | `elements`      | Mandatory   |
+|           | `element-list`  | Mandatory   |
 |           | `authority`     | Mandatory   |
-|           | `cm type`       | Mandatory   |
+|           | `cmtype`        | Mandatory   |
 |           | `profile`       | Optional    |
 {: #tbl-policy-ect-optionality title="Policy tuple requirements"}
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1578,20 +1578,22 @@ The Conceptual Message type determines which attributes are mandatory.
 
 An internal representation of attestation Evidence uses the `ae` relation.
 
+~~~ cddl
+{::include cddl/intrep-ae.cddl}
+~~~
+
 The `addition` is a list of ECTs with Evidence to be appraised.
 
 A Verifier may maintain multiple simultaneous sessions to different Attesters.
 Each Attester has a different ACS. The Verifier ensures the Evidence inputs are associated with the correct ACS.
 The `addition` is added to the ACS for a specific Attester.
 
-~~~ cddl
-{::include cddl/intrep-ae.cddl}
-~~~
+{{tbl-ae-ect-optionality}} contains the requirements for the ECT fields of the Evidence tuple:
 
 | ECT type  | ECT Field       | Requirement |
 |---
 | addition  | `environment`   | Mandatory   |
-|           | `element-list` | Mandatory   |
+|           | `element-list`  | Mandatory   |
 |           | `authority`     | Mandatory   |
 |           | `cmtype`        | Mandatory   |
 |           | `profile`       | Optional    |
@@ -1601,20 +1603,22 @@ The `addition` is added to the ACS for a specific Attester.
 
 An internal representation of Reference Values uses the `rv` relation, which is a list of ECTs that contains possible states and a list of ECTs that contain actual states asserted with RVP authority.
 
+~~~ cddl
+{::include cddl/intrep-rv.cddl}
+~~~
+
 The `rv` relation is a list of condition-addition pairings where each pairing is evaluated together.
 If the `condition` containing reference ECTs overlaps Evidence ECTs then the Evidence ECTs are re-asserted, but with RVP authority as contained in the `addition`.
 
 The reference ECTs define the matching conditions that are applied to Evidence ECTs.
 If the matching condition is satisfied, then the re-asserted ECTs are added to the ACS.
 
-~~~ cddl
-{::include cddl/intrep-rv.cddl}
-~~~
+{{tbl-rv-ect-optionality}} contains the requirements for the ECT fields of the Reference Values tuple:
 
 | ECT type  | ECT Field       | Requirement |
 |---
 | condition | `environment`   | Mandatory   |
-|           | `element-list` | Mandatory   |
+|           | `element-list`  | Mandatory   |
 |           | `authority`     | Optional    |
 |           | `cmtype`        | n/a         |
 |           | `profile`       | n/a         |
@@ -1629,15 +1633,17 @@ If the matching condition is satisfied, then the re-asserted ECTs are added to t
 
 An internal representation of Endorsed Values uses the `ev` and `evs` relations, which are lists of ECTs that describe matching conditions and the additions that are added if the conditions are satisfied.
 
+~~~ cddl
+{::include cddl/intrep-ev.cddl}
+~~~
+
 The `ev` relation compares the `condition` ECTs to the ACS and if all of the ECTs are found in the ACS then the `addition` ECTs are added to the ACS.
 
 The `evs` relation compares the `condition` ECTs to the ACS and if all of the ECTs are found in the ACS then each entry in the series list is evaluated.
 The `selection` ECTs are compared with the ACS and if the selection criteria is satisfied, then the `addition` ECTs are added to the ACS and evaluation of the series ends.
 If the `selection` criteria is not satisfied, then evaluation procedes to the next series list entry.
 
-~~~ cddl
-{::include cddl/intrep-ev.cddl}
-~~~
+{{tbl-ev-ect-optionality}} contains the requirements for the ECT fields of the Endorsed Values and Endorsed Values Series tuples:
 
 | ECT type  | ECT Field       | Requirement |
 |---
@@ -1661,11 +1667,14 @@ If the `selection` criteria is not satisfied, then evaluation procedes to the ne
 #### Internal Representation of Policy Statements {#sec-ir-policy}
 
 The `policy` relation compares the `condition` ECTs to the ACS.
-If all of the ECTs are found in the ACS then the `addition` ECTs are added to the ACS with the policy author's authority.
 
 ~~~ cddl
 {::include cddl/intrep-policy.cddl}
 ~~~
+
+If all of the ECTs are found in the ACS then the `addition` ECTs are added to the ACS with the policy author's authority.
+
+{{tbl-policy-ect-optionality}} contains the requirements for the ECT fields of the Policy tuple:
 
 | ECT type  | ECT Field       | Requirement |
 |---
@@ -1684,12 +1693,15 @@ If all of the ECTs are found in the ACS then the `addition` ECTs are added to th
 #### Internal Representation of Attestation Results {#sec-ir-ar}
 
 The `ar` relation compares the `acs-condition` to the ACS.
-If the condition is satisfied, the `ars-additions` are copied from the ACS to the ARS.
-If any of the `ars-additions` are not found in the ACS then these ACS entries are not copied to the ARS.
 
 ~~~ cddl
 {::include cddl/intrep-ar.cddl}
 ~~~
+
+If the condition is satisfied, the `ars-additions` are copied from the ACS to the ARS.
+If any of the `ars-additions` are not found in the ACS then these ACS entries are not copied to the ARS.
+
+{{tbl-ar-ect-optionality}} contains the requirements for the ECT fields of the Attestation Results tuple:
 
 | ECT type      | ECT Field       | Requirement |
 |---

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1621,7 +1621,7 @@ If the matching condition is satisfied, then the re-asserted ECTs are added to t
 | addition  | `environment`   | Mandatory   |
 |           | `element-list`  | Mandatory   |
 |           | `authority`     | Mandatory   |
-|           | `cm type`       | Mandatory   |
+|           | `cmtype`        | Mandatory   |
 |           | `profile`       | Optional    |
 {: #tbl-rv-ect-optionality title="Reference Values tuple requirements"}
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1642,7 +1642,7 @@ If the `selection` criteria is not satisfied, then evaluation procedes to the ne
 | ECT type  | ECT Field       | Requirement |
 |---
 | condition | `environment`   | Mandatory   |
-|           | `elements`      | Mandatory   |
+|           | `element-list`  | Mandatory   |
 |           | `authority`     | Optional    |
 |           | `cm type`       | n/a         |
 |           | `profile`       | n/a         |

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1588,12 +1588,14 @@ The `addition` is added to the ACS for a specific Attester.
 {::include cddl/intrep-ae.cddl}
 ~~~
 
-| Type | `en` | `el` | `a` | `cm` | `p` |
+| ECT type  | ECT Field       | Requirement |
 |---
-| addition | T | T | T | T | F |
-{: #tbl-ae-ect-optionality title="Mandatory fields for Evidence tuples"}
-
-'T' means mandatory.
+| addition  | `environment`   | Mandatory   |
+|           | `elements`      | Mandatory   |
+|           | `authority`     | Mandatory   |
+|           | `cm type`       | Mandatory   |
+|           | `profile`       | Optional    |
+{: #tbl-ae-ect-optionality title="Evidence tuple requirements"}
 
 #### Internal Representation of Reference Values {#sec-ir-ref-val}
 
@@ -1609,11 +1611,19 @@ If the matching condition is satisfied, then the re-asserted ECTs are added to t
 {::include cddl/intrep-rv.cddl}
 ~~~
 
-| Type | `en` | `el` | `a` | `cm` | `p` |
+| ECT type  | ECT Field       | Requirement |
 |---
-| condition | T | T | F | F | F |
-| addition  | T | T | T | T | F |
-{: #tbl-rv-ect-optionality title="Mandatory fields for Reference Values tuples"}
+| condition | `environment`   | Mandatory   |
+|           | `elements`      | Mandatory   |
+|           | `authority`     | Optional    |
+|           | `message type`  | n/a         |
+|           | `profile`       | n/a         |
+| addition  | `environment`   | Mandatory   |
+|           | `elements`      | Mandatory   |
+|           | `authority`     | Mandatory   |
+|           | `cm type`       | Mandatory   |
+|           | `profile`       | Optional    |
+{: #tbl-rv-ect-optionality title="Reference Values tuple requirements"}
 
 #### Internal Representation of Endorsed Values {#sec-ir-end-val}
 
@@ -1629,12 +1639,24 @@ If the `selection` criteria is not satisfied, then evaluation procedes to the ne
 {::include cddl/intrep-ev.cddl}
 ~~~
 
-| Type | `en` | `el` | `a` | `cm` | `p` |
+| ECT type  | ECT Field       | Requirement |
 |---
-| condition | F | T | F | F | F |
-| selection | F | T | F | F | F |
-| addition  | T | T | T | T | F |
-{: #tbl-ev-ect-optionality title="Mandatory fields for Endorsed Values tuples"}
+| condition | `environment`   | Mandatory   |
+|           | `elements`      | Mandatory   |
+|           | `authority`     | Optional    |
+|           | `message type`  | n/a         |
+|           | `profile`       | n/a         |
+| selection | `environment`   | Optional    |
+|           | `elements`      | Mandatory   |
+|           | `authority`     | n/a         |
+|           | `message type`  | n/a         |
+|           | `profile`       | n/a         |
+| addition  | `environment`   | Mandatory   |
+|           | `elements`      | Mandatory   |
+|           | `authority`     | Mandatory   |
+|           | `cm type`       | Mandatory   |
+|           | `profile`       | Optional    |
+{: #tbl-ev-ect-optionality title="Endorsed Values and Endorsed Values Series tuples requirements"}
 
 #### Internal Representation of Policy Statements {#sec-ir-policy}
 
@@ -1645,11 +1667,19 @@ If all of the ECTs are found in the ACS then the `addition` ECTs are added to th
 {::include cddl/intrep-policy.cddl}
 ~~~
 
-| Type | `en` | `el` | `a` | `cm` | `p` |
+| ECT type  | ECT Field       | Requirement |
 |---
-| condition | F | F | F | F | F |
-| addition  | T | T | T | T | F |
-{: #tbl-policy-ect-optionality title="Mandatory fields for policy tuples"}
+| condition | `environment`   | Optional    |
+|           | `elements`      | Optional    |
+|           | `authority`     | Optional    |
+|           | `message type`  | n/a         |
+|           | `profile`       | n/a         |
+| addition  | `environment`   | Mandatory   |
+|           | `elements`      | Mandatory   |
+|           | `authority`     | Mandatory   |
+|           | `cm type`       | Mandatory   |
+|           | `profile`       | Optional    |
+{: #tbl-policy-ect-optionality title="Policy tuple requirements"}
 
 #### Internal Representation of Attestation Results {#sec-ir-ar}
 
@@ -1661,11 +1691,19 @@ If any of the `ars-additions` are not found in the ACS then these ACS entries ar
 {::include cddl/intrep-ar.cddl}
 ~~~
 
-| Type | `en` | `el` | `a` | `cm` | `p` |
+| ECT type      | ECT Field       | Requirement |
 |---
-| acs-condition | F | F | F | F | F |
-| ars-addition  | T | T | T | F | F |
-{: #tbl-ar-ect-optionality title="Mandatory fields for Attestation Results tuples"}
+| acs-condition | `environment`   | Optional    |
+|               | `elements`      | Optional    |
+|               | `authority`     | Optional    |
+|               | `message type`  | n/a         |
+|               | `profile`       | n/a         |
+| ars-addition  | `environment`   | Mandatory   |
+|               | `elements`      | Mandatory   |
+|               | `authority`     | Mandatory   |
+|               | `cm type`       | Mandatory   |
+|               | `profile`       | Optional    |
+{: #tbl-ar-ect-optionality title="Attestation Results tuple requirements"}
 
 ### Internal Representation of ACS {#sec-ir-acs}
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1591,7 +1591,7 @@ The `addition` is added to the ACS for a specific Attester.
 | ECT type  | ECT Field       | Requirement |
 |---
 | addition  | `environment`   | Mandatory   |
-|           | `elements`      | Mandatory   |
+|           | `element-list` | Mandatory   |
 |           | `authority`     | Mandatory   |
 |           | `cm type`       | Mandatory   |
 |           | `profile`       | Optional    |

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1619,7 +1619,7 @@ If the matching condition is satisfied, then the re-asserted ECTs are added to t
 |           | `cmtype`        | n/a         |
 |           | `profile`       | n/a         |
 | addition  | `environment`   | Mandatory   |
-|           | `elements`      | Mandatory   |
+|           | `element-list`  | Mandatory   |
 |           | `authority`     | Mandatory   |
 |           | `cm type`       | Mandatory   |
 |           | `profile`       | Optional    |

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1654,7 +1654,7 @@ If the `selection` criteria is not satisfied, then evaluation procedes to the ne
 | addition  | `environment`   | Mandatory   |
 |           | `element-list`  | Mandatory   |
 |           | `authority`     | Mandatory   |
-|           | `cm type`       | Mandatory   |
+|           | `cmtype`        | Mandatory   |
 |           | `profile`       | Optional    |
 {: #tbl-ev-ect-optionality title="Endorsed Values and Endorsed Values Series tuples requirements"}
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1616,7 +1616,7 @@ If the matching condition is satisfied, then the re-asserted ECTs are added to t
 | condition | `environment`   | Mandatory   |
 |           | `element-list` | Mandatory   |
 |           | `authority`     | Optional    |
-|           | `cm type`       | n/a         |
+|           | `cmtype`        | n/a         |
 |           | `profile`       | n/a         |
 | addition  | `environment`   | Mandatory   |
 |           | `elements`      | Mandatory   |

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1644,7 +1644,7 @@ If the `selection` criteria is not satisfied, then evaluation procedes to the ne
 | condition | `environment`   | Mandatory   |
 |           | `element-list`  | Mandatory   |
 |           | `authority`     | Optional    |
-|           | `cm type`       | n/a         |
+|           | `cmtype`        | n/a         |
 |           | `profile`       | n/a         |
 | selection | `environment`   | Optional    |
 |           | `element-list`  | Mandatory   |

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1652,7 +1652,7 @@ If the `selection` criteria is not satisfied, then evaluation procedes to the ne
 |           | `cmtype`        | n/a         |
 |           | `profile`       | n/a         |
 | addition  | `environment`   | Mandatory   |
-|           | `elements`      | Mandatory   |
+|           | `element-list`  | Mandatory   |
 |           | `authority`     | Mandatory   |
 |           | `cm type`       | Mandatory   |
 |           | `profile`       | Optional    |

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1646,9 +1646,9 @@ If the `selection` criteria is not satisfied, then evaluation procedes to the ne
 |           | `authority`     | Optional    |
 |           | `cmtype`        | n/a         |
 |           | `profile`       | n/a         |
-| selection | `environment`   | Optional    |
+| selection | `environment`   | Mandatory   |
 |           | `element-list`  | Mandatory   |
-|           | `authority`     | n/a         |
+|           | `authority`     | Optional    |
 |           | `cmtype`        | n/a         |
 |           | `profile`       | n/a         |
 | addition  | `environment`   | Mandatory   |

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1616,7 +1616,7 @@ If the matching condition is satisfied, then the re-asserted ECTs are added to t
 | condition | `environment`   | Mandatory   |
 |           | `elements`      | Mandatory   |
 |           | `authority`     | Optional    |
-|           | `message type`  | n/a         |
+|           | `cm type`       | n/a         |
 |           | `profile`       | n/a         |
 | addition  | `environment`   | Mandatory   |
 |           | `elements`      | Mandatory   |
@@ -1644,12 +1644,12 @@ If the `selection` criteria is not satisfied, then evaluation procedes to the ne
 | condition | `environment`   | Mandatory   |
 |           | `elements`      | Mandatory   |
 |           | `authority`     | Optional    |
-|           | `message type`  | n/a         |
+|           | `cm type`       | n/a         |
 |           | `profile`       | n/a         |
 | selection | `environment`   | Optional    |
 |           | `elements`      | Mandatory   |
 |           | `authority`     | n/a         |
-|           | `message type`  | n/a         |
+|           | `cm type`       | n/a         |
 |           | `profile`       | n/a         |
 | addition  | `environment`   | Mandatory   |
 |           | `elements`      | Mandatory   |
@@ -1672,7 +1672,7 @@ If all of the ECTs are found in the ACS then the `addition` ECTs are added to th
 | condition | `environment`   | Optional    |
 |           | `elements`      | Optional    |
 |           | `authority`     | Optional    |
-|           | `message type`  | n/a         |
+|           | `cm type`       | n/a         |
 |           | `profile`       | n/a         |
 | addition  | `environment`   | Mandatory   |
 |           | `elements`      | Mandatory   |
@@ -1696,7 +1696,7 @@ If any of the `ars-additions` are not found in the ACS then these ACS entries ar
 | acs-condition | `environment`   | Optional    |
 |               | `elements`      | Optional    |
 |               | `authority`     | Optional    |
-|               | `message type`  | n/a         |
+|               | `cm type`  | n/a         |
 |               | `profile`       | n/a         |
 | ars-addition  | `environment`   | Mandatory   |
 |               | `elements`      | Mandatory   |

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1649,7 +1649,7 @@ If the `selection` criteria is not satisfied, then evaluation procedes to the ne
 | selection | `environment`   | Optional    |
 |           | `elements`      | Mandatory   |
 |           | `authority`     | n/a         |
-|           | `cm type`       | n/a         |
+|           | `cmtype`        | n/a         |
 |           | `profile`       | n/a         |
 | addition  | `environment`   | Mandatory   |
 |           | `elements`      | Mandatory   |

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1614,7 +1614,7 @@ If the matching condition is satisfied, then the re-asserted ECTs are added to t
 | ECT type  | ECT Field       | Requirement |
 |---
 | condition | `environment`   | Mandatory   |
-|           | `elements`      | Mandatory   |
+|           | `element-list` | Mandatory   |
 |           | `authority`     | Optional    |
 |           | `cm type`       | n/a         |
 |           | `profile`       | n/a         |


### PR DESCRIPTION
Updated ECT requirements tables for internal representations of conceptual messages to use human readable table elements.

Note: the new table format allows for n/a in addition to Mandatory and Optional. 

Fixes issue #287 