### PR TITLE
Define raw public key

### DIFF
--- a/cddl/crypto-key-type-choice.cddl
+++ b/cddl/crypto-key-type-choice.cddl
@@ -6,6 +6,7 @@ $crypto-key-type-choice /= tagged-thumbprint-type
 $crypto-key-type-choice /= tagged-cert-thumbprint-type
 $crypto-key-type-choice /= tagged-cert-path-thumbprint-type
 $crypto-key-type-choice /= tagged-pkix-asn1der-cert-type
+$crypto-key-type-choice /= tagged-bytes
 
 tagged-pkix-base64-key-type = #6.554(tstr)
 tagged-pkix-base64-cert-type = #6.555(tstr)

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -70,7 +70,6 @@ contributor:
 normative:
   RFC4122: uuid
   RFC5280: pkix-cert
-  RFC7250: raw-pk
   RFC7468: pkix-text
   RFC8610: cddl
   RFC9090: cbor-oids
@@ -1026,10 +1025,13 @@ A cryptographic key can be one of the following formats:
 * `tagged-cose-key-type`: CBOR encoded COSE_Key or COSE_KeySet.
   Defined in {{Section 7 of -cose}}.
 
+* `tagged-pkix-asn1der-cert-type`: a `bstr` of ASN.1 DER encoded X.509 public key certificate.
+  Defined in {{Section 4 of -pkix-cert}}.
+
 A cryptographic key digest can be one of the following formats:
 
-* `tagged-thumbprint-type`: a `digest` of a raw public key as defined in {{-raw-pk}}. The digest value may
-  be used to find the public key if contained in a lookup table.
+* `tagged-thumbprint-type`: a `digest` of a raw public key.
+  The digest value may be used to find the public key if contained in a lookup table.
 
 * `tagged-cert-thumbprint-type`: a `digest` of a certificate.
   The digest value may be used to find the certificate if contained in a lookup table.
@@ -1037,8 +1039,7 @@ A cryptographic key digest can be one of the following formats:
 * `tagged-cert-path-thumbprint-type`: a `digest` of a certification path.
   The digest value may be used to find the certificate path if contained in a lookup table.
 
-* `tagged-pkix-asn1der-key-type`: a `bstr` of ASN.1 DER encoded X.509 public key certificate.
-  Defined in {{Section 4 of -pkix-cert}}.
+* `tagged-bytes`: a key identifier with no prescribed construction method.
 
 ~~~ cddl
 {::include cddl/crypto-key-type-choice.cddl}

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -70,6 +70,7 @@ contributor:
 normative:
   RFC4122: uuid
   RFC5280: pkix-cert
+  RFC7250: raw-pk
   RFC7468: pkix-text
   RFC8610: cddl
   RFC9090: cbor-oids
@@ -1027,7 +1028,7 @@ A cryptographic key can be one of the following formats:
 
 A cryptographic key digest can be one of the following formats:
 
-* `tagged-thumbprint-type`: a `digest` of a raw public key. The digest value may
+* `tagged-thumbprint-type`: a `digest` of a raw public key as defined in {{-raw-pk}}. The digest value may
   be used to find the public key if contained in a lookup table.
 
 * `tagged-cert-thumbprint-type`: a `digest` of a certificate.


### PR DESCRIPTION
Raw still needs an encoding. Taking this to mean the RawPublicKey encoding defined in TLS 1.3.