### PR TITLE
Allow mkey tstr

### DIFF
--- a/cddl/examples/comid-3.diag
+++ b/cddl/examples/comid-3.diag
@@ -28,6 +28,38 @@
               / hash-alg-id / 6, / sha-256-32 /
               / hash-value /  h'ABCDEF00' ]]
             }
+          },
+            / measurement-map / {
+            / comid.mkey / 0: "my_element",
+            / comid.mval / 1 : {
+              / comid.digests / 2 : [[
+              / hash-alg-id / 6, / sha-256-32 /
+              / hash-value /  h'00FEDCBA' ]]
+            }
+          },
+            / measurement-map / {
+            / comid.mkey / 0: 111( h'5502C001' ),
+            / comid.mval / 1 : {
+              / comid.digests / 2 : [[
+              / hash-alg-id / 6, / sha-256-32 /
+              / hash-value /  h'00FEDCBA' ]]
+            }
+          },
+            / measurement-map / {
+            / comid.mkey / 0: 37( h'67b28b6c34cc40a19117ab5b05911e38' ),
+            / comid.mval / 1 : {
+              / comid.digests / 2 : [[
+              / hash-alg-id / 6, / sha-256-32 /
+              / hash-value /  h'00FEDCBA' ]]
+            }
+          },
+            / measurement-map / {
+            / anonymous mkey /
+            / comid.mval / 1 : {
+              / comid.digests / 2 : [[
+              / hash-alg-id / 6, / sha-256-32 /
+              / hash-value /  h'11223344' ]]
+            }
           }
         ]
       ]

--- a/cddl/measured-element-type-choice.cddl
+++ b/cddl/measured-element-type-choice.cddl
@@ -1,3 +1,4 @@
 $measured-element-type-choice /= tagged-oid-type
 $measured-element-type-choice /= tagged-uuid-type
 $measured-element-type-choice /= uint
+$measured-element-type-choice /= tstr

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -812,7 +812,7 @@ The following describes each member of the `measurement-map`:
 ###### Measurement Keys {#sec-comid-mkey}
 
 Measurement keys are locally scoped extensible identifiers.
-The initial types defined are OID, UUID, and uint.
+The initial types defined are OID, UUID, uint, and tstr.
 `mkey` may be necessary to disambiguate multiple measurements of the same type or to distinguish multiple measured elements within the same environment.
 A single anonymous `measurement-map` is allowed within the same environment.
 Two or more measurement-map entries within the same environment MUST populate `mkey`.


### PR DESCRIPTION
Added tstr to $measured-element-type-choice.

Fix #312