### PR TITLE
Allow signing untagged corim-map

### DIFF
--- a/cddl/corim-frags.mk
+++ b/cddl/corim-frags.mk
@@ -61,6 +61,7 @@ CORIM_FRAGS += corim-meta-map.cddl
 CORIM_FRAGS += corim-role-type-choice.cddl
 CORIM_FRAGS += corim-signer-map.cddl
 CORIM_FRAGS += cose-sign1-corim.cddl
+CORIM_FRAGS += maybe-tagged-corim-map.cddl
 CORIM_FRAGS += profile-type-choice.cddl
 CORIM_FRAGS += protected-corim-header-map.cddl
 CORIM_FRAGS += signed-corim.cddl

--- a/cddl/cose-sign1-corim.cddl
+++ b/cddl/cose-sign1-corim.cddl
@@ -1,6 +1,6 @@
 COSE-Sign1-corim = [
   protected: bstr .cbor protected-corim-header-map
   unprotected: unprotected-corim-header-map
-  payload: bstr .cbor tagged-corim-map
+  payload: bstr .cbor maybe-tagged-corim-map
   signature: bstr
 ]

--- a/cddl/maybe-tagged-corim-map.cddl
+++ b/cddl/maybe-tagged-corim-map.cddl
@@ -1,0 +1,2 @@
+maybe-tagged-corim-map = corim-map / tagged-corim-map
+


### PR DESCRIPTION
There's no need to require the tag, and the veraison/corim package hasn't been tagging its payload.