### PR TITLE
Add locator redundancy for listing mirrors.

### DIFF
--- a/cddl/corim-locator-map.cddl
+++ b/cddl/corim-locator-map.cddl
@@ -1,4 +1,4 @@
 corim-locator-map = {
-  &(href: 0) => uri
+  &(href: 0) => uri / [ + uri ]
   ? &(thumbprint: 1) => digest
 }

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -345,7 +345,7 @@ certificates, or other relevant information can be retrieved by the Verifier.
 
 The following describes each child element of this type.
 
-* `href` (index 0): a URI or array of redundant URIs identifying locations where the additional resource can be fetched.
+* `href` (index 0): a URI or array of alternative URIs identifying locations where the additional resource can be fetched.
 
 * `thumbprint` (index 1): expected digest of the resource referenced by `href`.
   See sec-common-hash-entry}}.

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -345,7 +345,7 @@ certificates, or other relevant information can be retrieved by the Verifier.
 
 The following describes each child element of this type.
 
-* `href` (index 0): a URI or array of rendundant URIs identifying locations where the additional resource can be fetched.
+* `href` (index 0): a URI or array of redundant URIs identifying locations where the additional resource can be fetched.
 
 * `thumbprint` (index 1): expected digest of the resource referenced by `href`.
   See sec-common-hash-entry}}.

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -345,7 +345,7 @@ certificates, or other relevant information can be retrieved by the Verifier.
 
 The following describes each child element of this type.
 
-* `href` (index 0): a URI or array of rendundant URIs identifying the additional resource that can be fetched.
+* `href` (index 0): a URI or array of rendundant URIs identifying locations where the additional resource can be fetched.
 
 * `thumbprint` (index 1): expected digest of the resource referenced by `href`.
   See sec-common-hash-entry}}.

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -345,7 +345,7 @@ certificates, or other relevant information can be retrieved by the Verifier.
 
 The following describes each child element of this type.
 
-* `href` (index 0): URI identifying the additional resource that can be fetched
+* `href` (index 0): a URI or array of rendundant URIs identifying the additional resource that can be fetched.
 
 * `thumbprint` (index 1): expected digest of the resource referenced by `href`.
   See sec-common-hash-entry}}.


### PR DESCRIPTION
Proposed change during discussion in Issue #358.