### PR TITLE
Rename tagged-corim-map to tagged-unsigned-corim

### DIFF
--- a/cddl/cbor-tags.txt
+++ b/cddl/cbor-tags.txt
@@ -1,4 +1,4 @@
-tagged-corim-map = #6.501(corim-map)
+tagged-unsigned-corim-map = #6.501(unsigned-corim-map)
 tagged-concise-swid-tag = #6.505(bytes .cbor concise-swid-tag)
 tagged-concise-mid-tag = #6.506(bytes .cbor concise-mid-tag)
 tagged-concise-tl-tag = #6.508(bytes .cbor concise-tl-tag)

--- a/cddl/corim-frags.mk
+++ b/cddl/corim-frags.mk
@@ -64,10 +64,10 @@ CORIM_FRAGS += cose-sign1-corim.cddl
 CORIM_FRAGS += profile-type-choice.cddl
 CORIM_FRAGS += protected-corim-header-map.cddl
 CORIM_FRAGS += signed-corim.cddl
-CORIM_FRAGS += tagged-corim-map.cddl
 CORIM_FRAGS += tagged-concise-swid-tag.cddl
 CORIM_FRAGS += tagged-concise-mid-tag.cddl
 CORIM_FRAGS += tagged-concise-tl-tag.cddl
+CORIM_FRAGS += tagged-unsigned-corim-map.cddl
 CORIM_FRAGS += unprotected-corim-header-map.cddl
 CORIM_FRAGS += validity-map.cddl
 

--- a/cddl/corim-map.cddl
+++ b/cddl/corim-map.cddl
@@ -7,3 +7,4 @@ corim-map = {
   ? &(entities: 5) => [ + corim-entity-map ]
   * $$corim-map-extension
 }
+unsigned-corim-map = corim-map

--- a/cddl/corim.cddl
+++ b/cddl/corim.cddl
@@ -1,4 +1,4 @@
 corim = concise-rim-type-choice
 
-concise-rim-type-choice /= tagged-corim-map
+concise-rim-type-choice /= tagged-unsigned-corim-map
 concise-rim-type-choice /= signed-corim

--- a/cddl/cose-sign1-corim.cddl
+++ b/cddl/cose-sign1-corim.cddl
@@ -1,6 +1,6 @@
 COSE-Sign1-corim = [
   protected: bstr .cbor protected-corim-header-map
   unprotected: unprotected-corim-header-map
-  payload: bstr .cbor tagged-corim-map
+  payload: bstr .cbor tagged-unsigned-corim-map
   signature: bstr
 ]

--- a/cddl/examples/corim-1.diag
+++ b/cddl/examples/corim-1.diag
@@ -1,4 +1,4 @@
-/ tagged-corim-map / 501({
+/ tagged-unsigned-corim-map / 501({
   / corim.id / 0 : h'284e6c3e5d9f4f6b851f5a4247f243a7',
   / corim.tags / 1 : [
     / concise-mid-tag / 506( <<

--- a/cddl/examples/corim-2.diag
+++ b/cddl/examples/corim-2.diag
@@ -1,4 +1,4 @@
-/ tagged-corim-map / 501({
+/ tagged-unsigned-corim-map / 501({
   / corim.id / 0 : h'284e6c3e5d9f4f6b851f5a4247f243a7',
   / corim.tags / 1 : [
     / concise-mid-tag / 506( <<

--- a/cddl/examples/corim-design-cd.diag
+++ b/cddl/examples/corim-design-cd.diag
@@ -1,4 +1,4 @@
-/ tagged-corim-map / 501({
+/ tagged-unsigned-corim-map / 501({
   / corim.id / 0 : h'0A2D9D8C56F74071B4F38065C37E4ACF',
    / corim.tags / 1 : [
     / concise-mid-tag / 506( <<

--- a/cddl/examples/corim-firmware-cd.diag
+++ b/cddl/examples/corim-firmware-cd.diag
@@ -1,4 +1,4 @@
-/ tagged-corim-map / 501({
+/ tagged-unsigned-corim-map / 501({
   / corim.id / 0 : h'29B834181A5C4E4EA53E8F8786BC8C5B',
   / corim.tags / 1 : [
    / concise-mid-tag / 506( <<

--- a/cddl/tagged-corim-map.cddl
+++ b/cddl/tagged-corim-map.cddl
@@ -1,1 +1,0 @@
-tagged-corim-map = #6.501(corim-map)

--- a/cddl/tagged-unsigned-corim-map.cddl
+++ b/cddl/tagged-unsigned-corim-map.cddl
@@ -1,0 +1,1 @@
+tagged-unsigned-corim-map = #6.501(unsigned-corim-map)

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -311,8 +311,9 @@ The following describes each child item of this map.
   structures to the `corim-map`.
   Described in {{sec-iana-corim}}.
 
+A `corim-map` is unsigned, and its tagged form is an entrypoint for parsing a CoRIM, so it is named `tagged-unsigned-corim-map`.
 ~~~ cddl
-{::include cddl/tagged-corim-map.cddl}
+{::include cddl/tagged-unsigned-corim-map.cddl}
 ~~~
 
 ### Identity {#sec-corim-id}
@@ -2618,7 +2619,7 @@ IANA is requested to allocate the following tags in the "CBOR Tags" registry {{!
 |     Tag | Data Item           | Semantics                                                     | Reference |
 |     --- | ---------           | ---------                                                     | --------- |
 |     500 | `tag`               | Reserved for backward compatibility                   | {{&SELF}} |
-|     501 | `map`               | A tagged-corim-map, see {{sec-corim-map}}                     | {{&SELF}} |
+|     501 | `map`               | A tagged-unsigned-corim-map, see {{sec-corim-map}}            | {{&SELF}} |
 | 502-504 | `any`               | Earmarked for CoRIM                                           | {{&SELF}} |
 |     505 | `bytes`             | A tagged-concise-swid-tag, see {{sec-corim-tags}}             | {{&SELF}} |
 |     506 | `bytes`             | A tagged-concise-mid-tag, see {{sec-corim-tags}}              | {{&SELF}} |
@@ -2645,7 +2646,7 @@ Tags designated as "Earmarked for CoRIM" can be reassigned by IANA based on advi
 ## CoRIM Map Registry {#sec-iana-corim}
 
 This document defines a new registry titled "CoRIM Map".
-The registry uses integer values as index values for items in 'unsigned-corim-map' CBOR maps.
+The registry uses integer values as index values for items in `corim-map` CBOR maps.
 
 Future registrations for this registry are to be made based on {{?RFC8126}} as follows:
 


### PR DESCRIPTION
This allows for better interpreting the tag as an entrypoint to a CoRIM document. This fixes the hanging reference to unsigned-corim-map noted in Issue #374.