### PR TITLE
Populate entity map registries

### DIFF
--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -2747,9 +2747,12 @@ All negative values are reserved for Private Use.
 Initial registrations for the "CoRIM Entity Map" registry are provided below.
 Assignments consist of an integer index value, the item name, and a reference to the defining specification.
 
-| Index | Item Name | Specification
+| Index | Item Name | Value Type | Specification
 |---
-| 0-255 | Unassigned
+| 0     | entity-name | `text` | Name of the entity responsible for the actions of the role. |
+| 1     | reg-id      | `uri`  | A URI associated with the organization that owns the entity name. |
+| 2     | role        | `[ + role-type-choice ]` | A type choice defining the roles that the entity is claiming. |
+| 3-255 | Unassigned
 {: #tbl-iana-corim-entity-map-items title="CoRIM Entity Map Items Initial Registrations"}
 
 ## CoRIM Signer Map Registry {#sec-iana-corim-signer-map}
@@ -2824,9 +2827,12 @@ All negative values are reserved for Private Use.
 Initial registrations for the "CoMID Entity Map" registry are provided below.
 Assignments consist of an integer index value, the item name, and a reference to the defining specification.
 
-| Index | Item Name | Specification
+| Index | Item Name | Value Type | Specification
 |---
-| 0-255 | Unassigned
+| 0     | entity-name | `text` | Name of the entity responsible for the actions of the role. |
+| 1     | reg-id      | `uri`  | A URI associated with the organization that owns the entity name. |
+| 2     | role        | `[ + role-type-choice ]` | A type choice defining the roles that the entity is claiming. |
+| 3-255 | Unassigned
 {: #tbl-iana-comid-entity-map-items title="CoMID Entity Map Items Initial Registrations"}
 
 ## CoMID Triples Map Registry {#sec-iana-triples-map}


### PR DESCRIPTION
The entries 0..2 are claimed by the entity-map macro. Closes Issue #401.