### PR TITLE
Require at most one signer in corim-entity-map

### DIFF
--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -492,6 +492,8 @@ specification.
 {::include cddl/corim-role-type-choice.cddl}
 ~~~
 
+The `corim-entity-map` MUST NOT contain two entities with the `manifest-signer` role.
+
 ## Signed CoRIM {#sec-corim-signed}
 
 ~~~ cddl


### PR DESCRIPTION
The corim-signer-map identifies a single entity as the signer. When only using unsigned CoRIMs and depending on the entities, there isn't a structural limitation to stating multiple entities as signers.

Unless we're saying that every hop through nodes requires adding oneself to the entities as manifest-signer, then we need to make that clear and change the text that the manifest-signer is the one that originated the CoRIM.