### PR TITLE
Allow optional claims-list

### DIFF
--- a/cddl/conditional-endorsement-series-triple-record.cddl
+++ b/cddl/conditional-endorsement-series-triple-record.cddl
@@ -1,4 +1,8 @@
 conditional-endorsement-series-triple-record = [
-  condition: stateful-environment-record
+  condition: [
+    environment: environment-map,
+    ? claims-list: [ + measurement-map ],
+    ? authorized-by: [ + $crypto-key-type-choice ]
+  ]
   series: [ + conditional-series-record ]
 ]

--- a/cddl/examples/comid-series.diag
+++ b/cddl/examples/comid-series.diag
@@ -9,8 +9,8 @@
   } ],
   / triples / 4 : {
     / conditional-endorsement-series-triples / 8 : [
-      [
-        [ / *** stateful-environment-record *** /
+      [ / *** first triple *** /
+        [ / *** Condition *** /
           / environment-map / {
             / class / 0 : {
               / class-id / 0 :
@@ -33,10 +33,10 @@
               ]
             } 
           ]
-        ], /*** end stateful-environment-record ***/
-        [ / *** series *** /
+        ], /*** end Condition ***/
+        [ / *** Series *** /
           [ / conditional-series-record #1 / 
-            [
+            [ / *** Selection *** /
               { / *** ref-val measurement-map *** /
                 / mval / 1 : / measurement-values-map / {
                   / ver / 0 : {
@@ -46,7 +46,7 @@
                 }
               }
             ],
-            [
+            [  / *** Addition *** / 
               { / *** endv-measurement-map *** /
                 / mval / 1 : / measurement-values-map / {
                   / name / 11: "-NO_CVE-"
@@ -55,7 +55,7 @@
             ]
           ],
           [ / conditional-series-record #2 /
-            [
+            [ / *** Selection *** /
               { / *** ref-val measurement-map *** /
                 / mval / 1 : / measurement-values-map / {
                   / ver / 0 : {
@@ -65,7 +65,7 @@
                 }
               }
             ],
-            [
+            [  / *** Addition *** / 
               { / *** endv-measurement-map *** /
                 / mval / 1 : / measurement-values-map / {
                   / name / 11: "CVE_WARNING"
@@ -74,7 +74,7 @@
             ]
           ],
           [ / conditional-series-record #3 /
-            [
+            [ / *** Selection *** /
               { / *** ref-val measurement-map *** /
                 / mval / 1 : / measurement-values-map / {
                   / ver / 0 : {
@@ -84,7 +84,83 @@
                 }
               }
             ],
-            [
+            [  / *** Addition *** / 
+              { / *** endv-measurement-map *** /
+                / mval / 1 : / measurement-values-map / {
+                  / name / 11: "CVE_VULNERABLE"
+                }
+              }
+            ]
+          ]
+        ] / *** end series *** /
+      ],
+      [ / *** second triple *** /
+        [ / *** Condition *** /
+          / environment-map / {
+            / class / 0 : {
+              / class-id / 0 :
+                / tagged-oid-type / 111(
+                  h'5502C000'
+                ),
+              / vendor / 1 : "ACME Inc.",
+              / model / 2 : "ACME RoadRunner Firmware"
+            }
+          },
+          / authorized-by / [
+            / tagged-pkix-base64-key-type / 554("base64_key_ACME_signer")
+          ]
+        ], /*** end Condition ***/
+        [ / *** Series *** /
+          [ / conditional-series-record #1 / 
+            [  / *** Selection *** / 
+              { / *** ref-val measurement-map *** /
+                / mval / 1 : / measurement-values-map / {
+                  / ver / 0 : {
+                    / version / 0 : "2.0.0"
+                  },
+                  / comid.svn / 1 : 552(3)
+                }
+              }
+            ],
+            [  / *** Addition *** / 
+              { / *** endv-measurement-map *** /
+                / mval / 1 : / measurement-values-map / {
+                  / name / 11: "-NO_CVE-"
+                }
+              }
+            ]
+          ],
+          [ / conditional-series-record #2 /
+            [  / *** Selection *** / 
+              { / *** ref-val measurement-map *** /
+                / mval / 1 : / measurement-values-map / {
+                  / ver / 0 : {
+                    / version / 0 : "1.0.0"
+                  },
+                  / comid.svn / 1 : 552(2)
+                }
+              }
+            ],
+            [  / *** Addition *** / 
+              { / *** endv-measurement-map *** /
+                / mval / 1 : / measurement-values-map / {
+                  / name / 11: "CVE_WARNING"
+                }
+              }
+            ]
+          ],
+          [ / conditional-series-record #3 /
+            [  / *** Selection *** / 
+              { / *** ref-val measurement-map *** /
+                / mval / 1 : / measurement-values-map / {
+                  / ver / 0 : {
+                    / version / 0 : "1.0.0"
+                  },
+                  / comid.svn / 1 : 552(1)
+                }
+              }
+            ],
+            [ / *** Addition *** / 
               { / *** endv-measurement-map *** /
                 / mval / 1 : / measurement-values-map / {
                   / name / 11: "CVE_VULNERABLE"

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1368,12 +1368,16 @@ The Conditional Endorsement Series Triple has the following structure:
 The `conditional-endorsement-series-triple-record` has the following parameters:
 
 * `condition`: Search criteria that locates Evidence, corroborated Evidence, or Endorsements.
+The condition is a record containing an `environment`, optional `claims-list`, and optional `authorized-by`.
+If both `authorized-by` and `claims-list.authorized-by` are populated then `claims-list.authorized-by` is ignored.
+
 * `series`: A set of selection-addition tuples.
 
 The `conditional-series-record` has the following parameters:
 
 * `selection`: Search criteria that locates Evidence, corroborated Evidence, or Endorsements from the `condition` result.
-* `addition`: Additional Endorsements if the `selection` criteria are satisfied.
+
+* `addition`: Endorsements that are added if the `selection` criteria are satisfied.
 
 To process a `conditional-endorsement-series-record` the `conditions` are compared with existing Evidence, corroborated Evidence, and Endorsements.
 If the search criteria are satisfied, the `series` tuples are processed.


### PR DESCRIPTION
Addresses issue #435 where `claims-list` can be optional. `authorized-by` is added into the `condition` since `claims-list` is optional.