### PR TITLE
Remove mandatory kid in schema

### DIFF
--- a/cddl/protected-corim-header-map.cddl
+++ b/cddl/protected-corim-header-map.cddl
@@ -1,7 +1,6 @@
 protected-corim-header-map = {
   &(alg: 1) => int
   &(content-type: 3) => "application/rim+cbor"
-  &(kid: 4) => bstr
   &(corim-meta: 8) => bstr .cbor corim-meta-map
   * cose-label => cose-value
 }

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -543,8 +543,6 @@ The following describes each child item of this map.
 
 * `content-type` (index 3): A string that represents the "MIME Content type" carried in the CoRIM payload.
 
-* `kid` (index 4): A byte string which is a key identity pertaining to the CoRIM Issuer.
-
 * `corim-meta` (index 8): A map that contains metadata associated with a signed CoRIM.
   Described in {{sec-corim-meta}}.
 


### PR DESCRIPTION
This addresses the first point in #477 by removing the mandatory `kid` (defined in [RFC9052](https://www.rfc-editor.org/rfc/rfc9052.html#name-common-cose-header-paramete)) in protected headers. Other key identification methods are available in COSE, such as `x5t/c/u`, defined in [RFC9360](https://www.rfc-editor.org/rfc/rfc9360.html#name-x509-cose-header-parameters).

I suggest it makes sense not specialize CoRIM in that respect, nor to limit its scope to signers using a specific subset of these mechanisms. If it helps, we could add a sentence along the lines of:

```
The cryptographic material to be used by the verifier can be identified through any method supported by COSE_Sign1, such as `kid` defined in RFC9052 or x5t/x5c/x5u as defined in RFC360 for example.
```