### PR TITLE
Fix typo in locator map CDDL

### DIFF
--- a/cddl/corim-locator-map.cddl
+++ b/cddl/corim-locator-map.cddl
@@ -2,5 +2,5 @@
 
 corim-locator-map = {
   &(href: 0) => uri / [ + uri ]
-  ? &(thumbprint: 1) => eatmc.digest / [ eatmc.digest ]
+  ? &(thumbprint: 1) => eatmc.digest / [ + eatmc.digest ]
 }


### PR DESCRIPTION
Fix definition of the thumbprint field inside corim-locator-map to indicate multiplicity inside the array variant of the field.