### PR TITLE
Triples cleanup

### DIFF
--- a/cddl/cose-sign1-corim.cddl
+++ b/cddl/cose-sign1-corim.cddl
@@ -1,7 +1,9 @@
 COSE-Sign1-corim = [
   protected: bstr .cbor protected-corim-header-map
   unprotected: unprotected-corim-header-map
-  payload: bstr .cbor tagged-unsigned-corim-map / hash-envelope-digest / nil
+  payload: bstr .cbor tagged-unsigned-corim-map /
+                      hash-envelope-digest /
+                      nil
   signature: bstr
 ]
 

--- a/cddl/protected-corim-header-map.cddl
+++ b/cddl/protected-corim-header-map.cddl
@@ -1,28 +1,29 @@
-; protected corim header map needs to contain at least one of corim-meta (8) or CWT-Claims (15)
-protected-corim-header-map = protected-corim-header-map-inline / protected-corim-header-map-hash-envelope
+; protected corim header map needs to contain at least one of
+; corim-meta (8) or CWT-Claims (15)
 
-protected-corim-header-map-inline =
-  {
-    &(alg: 1) => int,
-    &(content-type: 3) => "application/rim+cbor",
-    meta-group,
-    * cose-label => cose-value
-  }
+protected-corim-header-map = protected-corim-header-map-inline /
+                             protected-corim-header-map-hash-envelope
 
-protected-corim-header-map-hash-envelope =
-  {
-    &(alg: 1) => int,
-    &(payload_hash_alg: 258) => int
-    &(payload_preimage_content_type: 259) => "application/rim+cbor",
-    ? &(payload_location: 260) => tstr
-    meta-group,
-    * cose-label => cose-value
-  }
+protected-corim-header-map-inline = {
+  &(alg: 1) => int
+  &(content-type: 3) => "application/rim+cbor"
+  meta-group
+  * cose-label => cose-value
+}
+
+protected-corim-header-map-hash-envelope = {
+  &(alg: 1) => int,
+  &(payload_hash_alg: 258) => int
+  &(payload_preimage_content_type: 259) => "application/rim+cbor"
+  ? &(payload_location: 260) => tstr
+  meta-group
+  * cose-label => cose-value
+}
 
 meta-group = ((
-        corim-meta-identity,
-        ? cwt-claims-identity,
-      ) // cwt-claims-identity)
+  corim-meta-identity,
+  ? cwt-claims-identity,
+) // cwt-claims-identity)
 
 corim-meta-identity = (&(corim-meta: 8) => bstr .cbor corim-meta-map)
 cwt-claims-identity = (&(CWT-Claims: 15) => cwt-claims)

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1413,7 +1413,7 @@ The Conditional Endorsement Triple has the following structure:
 
 The `conditional-endorsement-triple-record` has the following parameters:
 
-* `conditions`: Search criteria that locates Evidence,  corroborated Evidence, or Endorsements.
+* `conditions`: Search criteria that locates Evidence, corroborated Evidence, or Endorsements.
 * `endorsements`: Additional Endorsements.
 
 To process a `conditional-endorsement-triple-record` the `conditions` are compared with existing Evidence, corroborated Evidence, and Endorsements.

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1395,7 +1395,7 @@ The `endorsed-triple-record` has the following parameters:
 * `endorsement`: Additional Endorsement Claims.
 
 To process a `endorsed-triple-record`, its `condition` is compared with existing Evidence, corroborated Evidence, and Endorsements.
-If the search criterion is satisfied, the contents of the triple are added to the Attester's actual state under the Endorser's authority.
+If the search criterion is satisfied, the endorsement is added to the Attester's actual state under the Endorser's authority.
 
 ### Conditional Endorsement Triple {#sec-comid-triple-cond-endors}
 

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -229,7 +229,7 @@ Domain:
 Endorsed values:
 : A set of characteristics of an Attester that do not appear in Evidence.
 For example, Endorsed Values may include testing or certification data related to a hardware or firmware module.
-Endorsed Values are said to be "conditional" when they apply if Attester's actual state matches Verifier's accepted Claims.
+Endorsed Values are said to be "conditional" when they apply if Attester's actual state matches certain conditions.
 See also {{Section 3 of -rats-endorsements}}.
 
 Environment:
@@ -1379,8 +1379,8 @@ Evidence Claims that are re-asserted using RVP authority are said to be "corrobo
 
 ### Endorsed Values Triple {#sec-comid-triple-endval}
 
-An Endorsed Values triple provides additional Endorsements - i.e., claims reflecting the actual state - for an existing Target Environment.
-For Endorsed Values Claims, the subject is a Target Environment, the object contains Endorsement Claims for the Environment, and the predicate defines semantics for how the object relates to the subject.
+Endorsed Values Triples provide additional Endorsements - i.e., claims reflecting actual state - for an existing Target Environment.
+In an Endorsed Values Triple, the subject identifies a Target Environment, the object contains Endorsement Claims for the Environment, and the predicate asserts that these represent actual state associated with the subject.
 
 The Endorsed Values Triple has the following structure:
 
@@ -1391,17 +1391,16 @@ The Endorsed Values Triple has the following structure:
 
 The `endorsed-triple-record` has the following parameters:
 
-* `condition`: Search criterion that locates an Evidence, corroborated Evidence, or Endorsements environment.
+* `condition`: Search criterion that locates an Evidence or Endorsements environment.
 * `endorsement`: Additional Endorsement Claims.
 
-To process a `endorsed-triple-record` the `condition` is compared with existing Evidence, corroborated Evidence, and Endorsements.
-If the search criterion is satisfied, the `endorsement` Claims are combined with the `condition` `environment-map` to form a new (actual state) entry.
-The new entry is added to the existing set of entries using the Endorser's authority.
+To process a `endorsed-triple-record`, its `condition` is compared with existing Evidence and Endorsements.
+If the search criterion is satisfied, the contents of the triple are added to the Attester's actual state under the Endorser's authority.
 
 ### Conditional Endorsement Triple {#sec-comid-triple-cond-endors}
 
-A Conditional Endorsement Triple declares one or more conditions that, once matched, results in augmenting the Attester's actual state with the Endorsement Claims.
-The conditions are expressed via `stateful-environment-records`, which match Target Environments from Evidence in certain reference state.
+Conditional Endorsement Triples declare one or more conditions that, once matched, results in augmenting the Attester's actual state with the Endorsement Claims.
+The conditions are expressed via `stateful-environment-record`s, which match Target Environments from Evidence in certain reference state.
 
 The Conditional Endorsement Triple has the following structure:
 
@@ -1414,7 +1413,7 @@ The Conditional Endorsement Triple has the following structure:
 
 The `conditional-endorsement-triple-record` has the following parameters:
 
-* `conditions`: Search criteria that locates Evidence, corroborated Evidence, or Endorsements.
+* `conditions`: Search criteria that locates Evidence or Endorsements.
 * `endorsements`: Additional Endorsements.
 
 To process a `conditional-endorsement-triple-record` the `conditions` are compared with existing Evidence, corroborated Evidence, and Endorsements.
@@ -1479,16 +1478,16 @@ The first `series` entry that successfully matches the `selection` criteria term
 
 ### Device Identity Triple {#sec-comid-triple-identity}
 
-Device Identity triples (see `identity-triples` in {{sec-comid-triples}}) endorse that the keys were securely provisioned to the named Target Environment.
+Device Identity Triples endorse that the listed keys were securely provisioned to the named Target Environment.
 A single Target Environment (as identified by `environment` and `mkey`) may contain one or more cryptographic keys.
 The existence of these keys is asserted in Evidence, Reference Values, or Endorsements.
 
 The device identity keys may have been used to authenticate the Attester device or may be held in reserve for later use.
 
-Device Identity triples instruct a Verifier to perform key validation checks, such as revocation, certificate path construction & verification, or proof of possession.
+Device Identity Triples instruct a Verifier to perform key validation checks, such as revocation, certificate path construction & verification, or proof of possession.
 The Verifier SHOULD verify keys contained in Device Identity triples.
 
-Additional details about how a key was provisioned or is protected may be asserted using Endorsements such as `endorsed-triples`.
+Additional details about how a key was provisioned or is protected may be asserted using Endorsements such as `endorsed-triple-record`s.
 
 Depending on key formatting, as defined by `$crypto-key-type-choice`, the Verifier may take different steps to locate and verify the key.
 
@@ -1516,13 +1515,13 @@ The Verifier MAY report key verification results as part of an error reporting f
 
 ### Attest Key Triple {#sec-comid-triple-attest-key}
 
-Attest Key triples (see `attest-key-triples` in {{sec-comid-triples}}) endorse that the keys were securely provisioned to the named Attesting Environment.
+Attest Key Triples endorse that the keys were securely provisioned to the named Attesting Environment.
 An Attesting Environment (as identified by `environment` and `mkey`) may contain one or more cryptographic keys.
 The existence of these keys is asserted in Evidence, Reference Values, or Endorsements.
 
 The attestation keys may have been used to sign Evidence or may be held in reserve for later use.
 
-Attest Key triples instruct a Verifier to perform key validation checks, such as revocation, certification path construction and validation, or proof of possession.
+Attest Key Triples instruct a Verifier to perform key validation checks, such as revocation, certification path construction and validation, or proof of possession.
 The Verifier SHOULD verify keys contained in Attest Key triples.
 
 Additional details about how a key was provisioned or is protected may be asserted using Endorsements such as `endorsed-triples`.

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1391,10 +1391,10 @@ The Endorsed Values Triple has the following structure:
 
 The `endorsed-triple-record` has the following parameters:
 
-* `condition`: Search criterion that locates an Evidence or Endorsements environment.
+* `condition`: Search criterion that locates an Evidence, corroborated Evidence, or Endorsements environment.
 * `endorsement`: Additional Endorsement Claims.
 
-To process a `endorsed-triple-record`, its `condition` is compared with existing Evidence and Endorsements.
+To process a `endorsed-triple-record`, its `condition` is compared with existing Evidence, corroborated Evidence, and Endorsements.
 If the search criterion is satisfied, the contents of the triple are added to the Attester's actual state under the Endorser's authority.
 
 ### Conditional Endorsement Triple {#sec-comid-triple-cond-endors}

--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1413,7 +1413,7 @@ The Conditional Endorsement Triple has the following structure:
 
 The `conditional-endorsement-triple-record` has the following parameters:
 
-* `conditions`: Search criteria that locates Evidence or Endorsements.
+* `conditions`: Search criteria that locates Evidence,  corroborated Evidence, or Endorsements.
 * `endorsements`: Additional Endorsements.
 
 To process a `conditional-endorsement-triple-record` the `conditions` are compared with existing Evidence, corroborated Evidence, and Endorsements.


### PR DESCRIPTION
Some cleaning up and alignment.

I collected a few fly-by notes:

## Endorsed values triples

I'd rather refer to §8 for processing than describe it vaguely here, because duplication introduces the risk of inconsistencies.  However, if we decide that a high-level description of the processing is acceptable, we need to clearly introduce the concept of ACS and possibly that of transformation earlier.

mkey is not part of the condition criteria.  This should be noted as it differs from other match logics.

## Conditional series triples

The "selection matching" prose made my head spin.  I left the section untouched because I am not sure that I understand it well enough to apply any changes.  Someone else needs to have a go at it.

## DIT/AKT

1. We say that additional details about key protection or provisioning can be supplied via EVTs, but it's not clear to me how that would work.
1. We say that the keys produce endorsements, but what form do these take exactly? Also, is it one per key? This seems to mirror the lack of precise information that we also have in §8.
1. There are a few SHOULDs here, but none of them explain when it is OK to skip the requirement.