### PR TITLE
fix: comid-7.diag example

### DIFF
--- a/cddl/examples/comid-7.diag
+++ b/cddl/examples/comid-7.diag
@@ -15,7 +15,7 @@
       [
         / measurement-map / {
           / comid.mval / 1 : {
-            / comid.int-range / 15 : 564([/ min: / 1, / max: / null])
+            / comid.int-range / 15 : 564([/ min: / 1, / max: / Infinity])
           }
         },
         / measurement-map / {


### PR DESCRIPTION
Replace null (which is invalid, according to the spec) for int-range.max with Inifinity.