### PR TITLE
Improve wording for endorsement triple

### DIFF
--- a/draft-ietf-rats-corim.md
+++ b/draft-ietf-rats-corim.md
@@ -1416,11 +1416,12 @@ The Endorsed Values Triple has the following structure:
 
 The `endorsed-triple-record` has the following parameters:
 
-* `condition`: Search criterion that locates an Evidence, corroborated Evidence, or Endorsements environment.
-* `endorsement`: Additional Endorsement Claims.
+* `condition`: A search criterion used to locate an Environment in existing ACS entries.
+* `endorsement`: Additional Claims to be associated with the located Environment.
 
-To process a `endorsed-triple-record`, its `condition` is compared with existing Evidence, corroborated Evidence, and Endorsements.
-If the search criterion is satisfied, the endorsement is added to the Attester's actual state under the Endorser's authority.
+To process an `endorsed-triple-record`, its condition is evaluated against existing ACS entries.
+When matching using the `authorized-by` attribute, it is compared with the `authority` attribute of the ACS entry.
+If the search criterion is satisfied — including the authority match if supplied — the endorsement Claims are added to the Attester’s actual state under the Endorser’s authority.
 
 ### Conditional Endorsement Triple {#sec-comid-triple-cond-endors}
 


### PR DESCRIPTION
Improved wording of endorsement triple to clarify how authoritized-by is used to match authority on ACS entries.

See Issue #588 